### PR TITLE
Fix search SSE JSON parse error

### DIFF
--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -217,6 +217,7 @@ export const streamChat = async (req, res) => {
             const fullResponse = JSON.stringify(searchResponse.data);
             res.write(`data: ${JSON.stringify({ content: `Unable to parse structured response. Full data: ${fullResponse}` })}\n\n`);
           } catch (e) {
+            console.error('Error parsing search results:', e);
             res.write(`data: ${JSON.stringify({ content: "Received search results but couldn't parse them." })}\n\n`);
           }
         }

--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -203,21 +203,21 @@ export const streamChat = async (req, res) => {
             searchResponse.data.result.choices[0].message) {
           
           const content = searchResponse.data.result.choices[0].message.content;
-          res.write(`data: ${content}\n\n`);
+          res.write(`data: ${JSON.stringify({ content })}\n\n`);
         } else if (searchResponse.data.choices && searchResponse.data.choices[0]) {
           // For OpenRouter format
           const content = searchResponse.data.choices[0].message.content;
-          res.write(`data: ${content}\n\n`);
+          res.write(`data: ${JSON.stringify({ content })}\n\n`);
         } else if (searchResponse.data.content) {
-          res.write(`data: ${searchResponse.data.content}\n\n`);
+          res.write(`data: ${JSON.stringify({ content: searchResponse.data.content })}\n\n`);
         } else {
           // If we can't find the content in the expected structure, try to send the whole response
           // This is a fallback for unexpected response structures
           try {
             const fullResponse = JSON.stringify(searchResponse.data);
-            res.write(`data: Unable to parse structured response. Full data: ${fullResponse}\n\n`);
+            res.write(`data: ${JSON.stringify({ content: `Unable to parse structured response. Full data: ${fullResponse}` })}\n\n`);
           } catch (e) {
-            res.write(`data: Received search results but couldn't parse them.\n\n`);
+            res.write(`data: ${JSON.stringify({ content: "Received search results but couldn't parse them." })}\n\n`);
           }
         }
         


### PR DESCRIPTION
## Summary
- ensure search streaming data is JSON to match frontend parser

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb6a138a88323962ae0abec3acc97