### PR TITLE
Fix model selector dropdown overflow

### DIFF
--- a/src/components/ChatWindow.styled.js
+++ b/src/components/ChatWindow.styled.js
@@ -19,7 +19,8 @@ export const ChatWindowContainer = styled.div`
     }
   }};
   position: relative;
-  overflow: hidden;
+  /* Use visible overflow so dropdown menus (e.g., model selector) aren't clipped */
+  overflow: visible;
   
   @media (max-width: 768px) {
     margin-left: 0; /* No margin on mobile - sidebar overlays */


### PR DESCRIPTION
## Summary
- allow ChatWindow container to show overflow so the model selector dropdown isn't clipped

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb77443288323a1761b4c5c81bc5e