### PR TITLE
Fix greeting offset when tools open

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,7 +74,7 @@ const FloatingMenuButton = styled.button`
 // Main Greeting Component
 const MainGreeting = styled.div`
   position: fixed;
-  top: 35%; /* Aligned with text input bar positioning */
+  top: ${props => props.$toolbarOpen ? '32%' : '35%'}; /* Adjust when toolbar is open */
   left: ${props => {
     const sidebarOffset = props.$sidebarCollapsed ? 0 : 140;
     let rightPanelOffset = 0;
@@ -108,7 +108,7 @@ const MainGreeting = styled.div`
   /* Adjustments for medium to small screens */
   @media (max-width: 768px) {
     left: 50% !important; /* Always center on mobile */
-    top: 30%; /* Maintain alignment with text input */
+    top: ${props => props.$toolbarOpen ? '27%' : '30%'}; /* Adjust on mobile */
     max-width: 90%; /* Reduce max-width on smaller screens */
     padding: 0 15px; 
     h1 {
@@ -119,7 +119,7 @@ const MainGreeting = styled.div`
   /* Adjustments for very small screens */
   @media (max-width: 480px) {
     left: 50% !important; /* Always center on mobile */
-    top: 30%; /* Maintain alignment with text input */
+    top: ${props => props.$toolbarOpen ? '27%' : '30%'}; /* Adjust on small screens */
     max-width: 95%; /* Allow slightly more width on very small screens */
     padding: 0 10px; 
     h1 {
@@ -348,6 +348,7 @@ const AppContent = () => {
   const [isWhiteboardOpen, setIsWhiteboardOpen] = useState(false);
   const [isEquationEditorOpen, setIsEquationEditorOpen] = useState(false);
   const [isGraphingOpen, setIsGraphingOpen] = useState(false);
+  const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const chatWindowRef = useRef(null);
 
   // Update settings when user changes
@@ -590,11 +591,12 @@ const AppContent = () => {
             
             {/* Main greeting that appears at the top of the page */}
             {settings.showGreeting && getCurrentChat()?.messages?.length === 0 && !hasAttachment && (
-              <MainGreeting 
-                $sidebarCollapsed={collapsed} 
+              <MainGreeting
+                $sidebarCollapsed={collapsed}
                 $whiteboardOpen={isWhiteboardOpen}
                 $equationEditorOpen={isEquationEditorOpen}
                 $graphingOpen={isGraphingOpen}
+                $toolbarOpen={isToolbarOpen}
               >
                 <h1 style={settings.theme === 'lakeside' ? { color: 'rgb(198, 146, 20)' } : {}}>
                   {settings.theme === 'lakeside' ? 'Andromeda' : `${greeting}${user ? `, ${user.username}` : ''}`}
@@ -642,6 +644,7 @@ const AppContent = () => {
               isGraphingOpen={isGraphingOpen}
               onToggleGraphing={() => setIsGraphingOpen(prev => !prev)}
               onCloseGraphing={() => setIsGraphingOpen(false)}
+              onToolbarToggle={setIsToolbarOpen}
             />
           </MainContentArea>
           

--- a/src/components/ChatInputArea.jsx
+++ b/src/components/ChatInputArea.jsx
@@ -38,6 +38,7 @@ const ChatInputArea = forwardRef(({
   isGraphingOpen, // New prop for graphing tool
   onToggleGraphing, // New prop for toggling graphing
   onCloseGraphing, // New prop for closing graphing
+  onToolbarToggle,
 }, ref) => {
   const theme = useTheme();
   const [inputMessage, setInputMessage] = useState('');
@@ -83,6 +84,12 @@ const ChatInputArea = forwardRef(({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [showToolbar]);
+
+  useEffect(() => {
+    if (onToolbarToggle) {
+      onToolbarToggle(showToolbar);
+    }
+  }, [showToolbar, onToolbarToggle]);
 
   const handleInternalSubmit = () => {
     if (isLoading || isProcessingFile) return;

--- a/src/components/ChatWindow.jsx
+++ b/src/components/ChatWindow.jsx
@@ -38,7 +38,8 @@ const ChatWindow = forwardRef(({
   onCloseEquationEditor,
   isGraphingOpen,
   onToggleGraphing,
-  onCloseGraphing
+  onCloseGraphing,
+  onToolbarToggle
 }, ref) => {
   const [selectedModel, setSelectedModel] = useState(initialSelectedModel || 'gemini-2-flash');
   const [isProcessingFile, setIsProcessingFile] = useState(false); 
@@ -358,8 +359,9 @@ const ChatWindow = forwardRef(({
         isGraphingOpen={isGraphingOpen}
         onToggleGraphing={onToggleGraphing}
         onCloseGraphing={onCloseGraphing}
+        onToolbarToggle={onToolbarToggle}
         // Pass inputFocusChange if ChatInputArea needs to inform ChatWindow about focus for header opacity effect
-        // onInputFocusChange={inputFocusChange} 
+        // onInputFocusChange={inputFocusChange}
       />
     </ChatWindowContainer>
   );


### PR DESCRIPTION
## Summary
- adjust the MainGreeting positioning based on toolbar state
- surface toolbar toggle state from ChatInputArea up to App

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fb758c4f083239f10fcef9f1dfd7d