### PR TITLE
Potential fix for code scanning alert no. 11: Server-side request forgery

### DIFF
--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -186,7 +186,11 @@ export const streamChat = async (req, res) => {
     if (doSearch) {
       try {
         // Call the search-process endpoint to get search results
-        const searchResponse = await axios.post(`${req.protocol}://${req.get('host')}/api/search-process`, {
+        const internalApiBaseUrl = process.env.INTERNAL_API_BASE_URL;
+        if (!internalApiBaseUrl) {
+          throw new Error("INTERNAL_API_BASE_URL is not configured");
+        }
+        const searchResponse = await axios.post(`${internalApiBaseUrl}/api/search-process`, {
           query: prompt,
           max_results: doDeepResearch ? 5 : 3,
           model_prompt: "Based on the search results above, please answer this question in a comprehensive way with the most up-to-date information. DO NOT mention or reference the sources in your answer, as they will be displayed separately.",


### PR DESCRIPTION
Potential fix for [https://github.com/Sculptor-AI/aiportal/security/code-scanning/11](https://github.com/Sculptor-AI/aiportal/security/code-scanning/11)

To fix the SSRF vulnerability, we should avoid using the untrusted `req.get('host')` value directly in constructing the URL. Instead, we can use a predefined, trusted base URL for internal API calls. This ensures that the hostname is not influenced by user input. 

Steps to implement the fix:
1. Define a trusted base URL for internal API calls in the environment configuration (e.g., `process.env.INTERNAL_API_BASE_URL`).
2. Replace the dynamic URL construction with the trusted base URL.
3. Ensure that the trusted base URL is validated during application startup to prevent misconfiguration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
