### PR TITLE
Fix typo in README closing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The frontend will automatically connect to the backend if the proper environment
 ---
 
 <div align="center">
-  <p>Made with ❤️ by Team Sculptor/p>
+  <p>Made with ❤️ by Team Sculptor</p>
   <p>
     <span style="background: #f0f2f5; padding: 6px 12px; border-radius: 20px; font-size: 14px; font-weight: 500;">v0.1.0</span>
   </p>


### PR DESCRIPTION
## Summary
- fix stray tag in README credits section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684115d501fc8323ac346f30caa35caa