### PR TITLE
Fix typos in docs and aiService

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The frontend will automatically connect to the backend if the proper environment
 ---
 
 <div align="center">
-  <p>Made with ❤️ by Team Sculptor/p>
+  <p>Made with ❤️ by Team Sculptor</p>
   <p>
     <span style="background: #f0f2f5; padding: 6px 12px; border-radius: 20px; font-size: 14px; font-weight: 500;">v0.1.0</span>
   </p>

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -15,7 +15,7 @@ console.log("Loaded API keys from environment:", {
   nvidia: NVIDIA_API_KEY ? "Present (value hidden)" : "Missing"
 });
 
-// Map updated model IDs to their respective API endpoints and fornpmmats
+// Map updated model IDs to their respective API endpoints and formats
 const MODEL_CONFIGS = {
   'gemini-2-flash': {
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent',


### PR DESCRIPTION
## Summary
- fix closing HTML tag in README
- correct typo in aiService comment

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684115cfb65083238d891bcd36879960