### PR TITLE
Fix settings panel contrast, theme placement, and clipping

### DIFF
--- a/frontend/src/components/NewSettingsPanel.jsx
+++ b/frontend/src/components/NewSettingsPanel.jsx
@@ -30,6 +30,7 @@ const SettingsContainer = styled.div`
     props.theme.sidebar || props.theme.background || '#f5f5f7'};
   color: ${props => props.theme.text};
   border-radius: 16px;
+  overflow: hidden;
   width: 900px;
   height: 650px;
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
@@ -269,7 +270,7 @@ const NavItem = styled.div`
   cursor: pointer;
   transition: background-color 0.2s;
   background-color: ${props => props.$active ? props.theme.accentSurface : 'transparent'};
-  color: ${props => props.$active ? props.theme.accentText : props.theme.text};
+  color: ${props => props.$active ? (props.theme.accentColor || props.theme.text) : props.theme.text};
   border-left: 3px solid ${props => props.$active ? props.theme.accentColor : 'transparent'};
   font-weight: ${props => props.$active ? '500' : 'normal'};
   
@@ -1429,30 +1430,7 @@ const SettingDescription = styled.p`
           {activeSection === 'general' && (
             <div>
               <SectionTitle>{t('settings.sections.general')}</SectionTitle>
-              
-              <SettingsRow>
-                <SettingsLabel>{t('settings.general.theme.label')}</SettingsLabel>
-                <SelectBox 
-                  value={localSettings.theme || 'light'}
-                  onChange={(e) => handleChange('theme', e.target.value)}
-                >
-                  {themeOptionValues.map(value => (
-                    <option key={value} value={value}>
-                      {getThemeLabel(value)}
-                    </option>
-                  ))}
-                </SelectBox>
-              </SettingsRow>
-              {localSettings.theme === 'custom' && (
-                <SettingGroup>
-                  <SettingLabel>Custom Theme Studio</SettingLabel>
-                  <CustomThemeEditor
-                    value={customThemeValues}
-                    onChange={handleCustomThemeChange}
-                  />
-                </SettingGroup>
-              )}
-              
+
               <SettingsRow>
                 <SettingsLabel>{t('settings.general.language.label')}</SettingsLabel>
                 <SelectBox 
@@ -1480,7 +1458,30 @@ const SettingDescription = styled.p`
           {activeSection === 'appearance' && (
             <div>
               <SectionTitle>{t('settings.sections.appearance')}</SectionTitle>
-              
+
+              <SettingGroup>
+                <SettingLabel>{t('settings.general.theme.label')}</SettingLabel>
+                <SelectBox
+                  value={localSettings.theme || 'light'}
+                  onChange={(e) => handleChange('theme', e.target.value)}
+                >
+                  {themeOptionValues.map(value => (
+                    <option key={value} value={value}>
+                      {getThemeLabel(value)}
+                    </option>
+                  ))}
+                </SelectBox>
+              </SettingGroup>
+              {localSettings.theme === 'custom' && (
+                <SettingGroup>
+                  <SettingLabel>Custom Theme Studio</SettingLabel>
+                  <CustomThemeEditor
+                    value={customThemeValues}
+                    onChange={handleCustomThemeChange}
+                  />
+                </SettingGroup>
+              )}
+
               <SettingGroup>
                 <SettingLabel>{t('settings.appearance.fontSize.label')}</SettingLabel>
                 <RadioGroup>


### PR DESCRIPTION
## Summary
- NavItem text now uses `accentColor` (not `accentText`) when active, so the selected nav row is readable on the tinted `accentSurface` background. Previously, light/sunrise themes rendered white text on a near-white tint, making the selected item invisible.
- Move the Theme dropdown from the General tab to the Appearance tab and switch it to the same `SettingGroup` pattern as Font Size / Family for visual consistency.
- Add `overflow: hidden` to `SettingsContainer` so the dark `MainContent` background no longer overflows the modal's rounded right corners.

## Test plan
- [ ] Open Settings on the light theme — selected nav item shows blue text on a blue tint, not white-on-white
- [ ] Switch through dark / oled / ocean / sunrise / lakeside — selected nav item stays readable
- [ ] Theme dropdown appears under Appearance, not General
- [ ] Settings modal has rounded corners on all four sides in dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)