### PR TITLE
Add Whisper voice-input fallback for Firefox/Safari

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.8.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@pkasila/react-katex": "^1.2.2",
     "@react-three/drei": "^10.4.2",

--- a/frontend/src/components/LiveModeUI.jsx
+++ b/frontend/src/components/LiveModeUI.jsx
@@ -7,7 +7,7 @@ import { DEFAULT_CHAT_MODEL_ID, DEEP_RESEARCH_MODEL_ID } from '../config/modelCo
 import { SCULPTOR_AI_SYSTEM_PROMPT } from '../prompts/sculptorAI-system-prompt';
 import { sendMessage } from '../services/aiService';
 import {
-  BrowserSpeechRecognitionSession,
+  createSpeechRecognitionSession,
   detectSpeechRecognitionSupport,
 } from '../services/browserSpeechRecognition';
 import kokoroTTSService, { DEFAULT_KOKORO_VOICE } from '../services/kokoroTTSService';
@@ -453,6 +453,19 @@ const ErrorBanner = styled.div`
   text-align: center;
 `;
 
+const Disclaimer = styled.div`
+  max-width: 520px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px dashed ${props => props.theme.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.14)'};
+  background: ${props => props.theme.isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)'};
+  color: ${props => props.theme.textSecondary || props.theme.text};
+  font-size: 0.78rem;
+  line-height: 1.4;
+  text-align: center;
+  opacity: 0.85;
+`;
+
 const MAX_TRANSCRIPT_TURNS = 10;
 
 const createTurnId = () => {
@@ -515,6 +528,9 @@ const LiveModeUI = ({ selectedModel, availableModels = [], onModelChange, onClos
   const [response, setResponse] = useState('');
   const [speechError, setSpeechError] = useState('');
   const [speechSupported, setSpeechSupported] = useState(null);
+  const [speechMode, setSpeechMode] = useState(null);
+  const [whisperProgress, setWhisperProgress] = useState(0);
+  const [whisperProgressLabel, setWhisperProgressLabel] = useState('');
 
   const cameraVideoRef = useRef(null);
   const screenVideoRef = useRef(null);
@@ -618,11 +634,13 @@ const LiveModeUI = ({ selectedModel, availableModels = [], onModelChange, onClos
       .then((support) => {
         if (mountedRef.current) {
           setSpeechSupported(Boolean(support.supported));
+          setSpeechMode(support.mode || null);
         }
       })
       .catch(() => {
         if (mountedRef.current) {
           setSpeechSupported(false);
+          setSpeechMode(null);
         }
       });
 
@@ -737,19 +755,20 @@ const LiveModeUI = ({ selectedModel, availableModels = [], onModelChange, onClos
   }, [modelIdForChat, speakAssistantText, ttsStatus]);
 
   const startRecording = useCallback(async () => {
-    if (isRecording || status === 'processing' || status === 'responding') {
+    if (isRecording || status === 'processing' || status === 'responding' || status === 'transcribing') {
       return;
     }
 
     const support = await detectSpeechRecognitionSupport('en-US');
     setSpeechSupported(Boolean(support.supported));
+    setSpeechMode(support.mode || null);
 
     if (!support.supported) {
-      setSpeechError('Speech recognition is not supported in this browser. Try Chrome or Edge for browser speech input.');
+      setSpeechError('Speech recognition is not supported in this browser. Try Chrome or Edge.');
       return;
     }
 
-    const recognitionSession = new BrowserSpeechRecognitionSession({
+    const recognitionSession = createSpeechRecognitionSession(support.mode, {
       language: 'en-US',
       onStart: () => {
         setIsRecording(true);
@@ -761,9 +780,34 @@ const LiveModeUI = ({ selectedModel, availableModels = [], onModelChange, onClos
       onTranscription: ({ transcript: nextTranscript }) => {
         setInputTranscription(nextTranscript || '');
       },
+      onProcessing: ({ status: processingStatus }) => {
+        if (processingStatus === 'transcribing') {
+          setIsRecording(false);
+          setStatus('transcribing');
+        }
+      },
+      onModelProgress: (event) => {
+        const value = typeof event?.progress === 'number'
+          ? (event.progress > 1 ? event.progress / 100 : event.progress)
+          : (typeof event?.loaded === 'number' && typeof event?.total === 'number' && event.total > 0
+            ? event.loaded / event.total
+            : null);
+
+        if (typeof value === 'number') {
+          setWhisperProgress(Math.max(0, Math.min(1, value)));
+        }
+
+        if (typeof event?.file === 'string') {
+          setWhisperProgressLabel(event.file.split('/').pop());
+        } else if (typeof event?.status === 'string') {
+          setWhisperProgressLabel(event.status.replace(/_/g, ' '));
+        }
+      },
       onEnd: ({ transcript: finalTranscript, error: recognitionError }) => {
         speechRecognitionRef.current = null;
         setIsRecording(false);
+        setWhisperProgress(0);
+        setWhisperProgressLabel('');
 
         if (recognitionError) {
           if (recognitionError.code !== 'no-speech') {
@@ -863,18 +907,21 @@ const LiveModeUI = ({ selectedModel, availableModels = [], onModelChange, onClos
   const liveDraft = normalizeText(inputTranscription);
   const liveResponse = normalizeText(response);
 
-  const orbActive = isRecording || isSpeaking || status === 'processing' || status === 'responding';
+  const orbActive = isRecording || isSpeaking || status === 'processing' || status === 'responding' || status === 'transcribing';
 
   const statusInfo = useMemo(() => {
     if (isSpeaking) return { text: 'Speaking', showDots: false };
     if (status === 'processing' || status === 'responding') {
       return { text: t('liveMode.status.thinking', 'Thinking'), showDots: true };
     }
+    if (status === 'transcribing') {
+      return { text: whisperProgressLabel || 'Transcribing', showDots: true };
+    }
     if (isRecording) return { text: t('liveMode.status.listening', 'Listening'), showDots: true };
     if (ttsStatus === 'loading') return { text: ttsProgressLabel, showDots: true };
     if (speechSupported === false) return { text: 'Speech input unavailable', showDots: false };
     return { text: isMuted ? 'Muted' : t('liveMode.status.ready', 'Tap the mic to start'), showDots: false };
-  }, [isMuted, isRecording, isSpeaking, speechSupported, status, t, ttsProgressLabel, ttsStatus]);
+  }, [isMuted, isRecording, isSpeaking, speechSupported, status, t, ttsProgressLabel, ttsStatus, whisperProgressLabel]);
 
   const transcriptText = useMemo(() => {
     if (isRecording && liveDraft) return liveDraft;
@@ -939,8 +986,20 @@ const LiveModeUI = ({ selectedModel, availableModels = [], onModelChange, onClos
             </LoadingBar>
           )}
 
+          {status === 'transcribing' && whisperProgress > 0 && whisperProgress < 1 && (
+            <LoadingBar>
+              <LoadingFill $value={whisperProgress} />
+            </LoadingBar>
+          )}
+
           {transcriptText && (
             <Transcript>{transcriptText}</Transcript>
+          )}
+
+          {speechMode === 'whisper' && !speechError && (
+            <Disclaimer>
+              Your browser doesn't support native voice input. Using on-device Whisper instead — the first recording downloads a model (~40&nbsp;MB) and may feel slow.
+            </Disclaimer>
           )}
 
           {activeError && <ErrorBanner>{activeError}</ErrorBanner>}

--- a/frontend/src/services/browserSpeechRecognition.js
+++ b/frontend/src/services/browserSpeechRecognition.js
@@ -2,6 +2,8 @@ const ON_DEVICE_READY = 'available';
 const ON_DEVICE_DOWNLOADABLE = 'downloadable';
 const ON_DEVICE_DOWNLOADING = 'downloading';
 
+const WHISPER_MODEL_ID = 'Xenova/whisper-tiny.en';
+
 const normalizeTranscript = (value = '') => value.replace(/\s+/g, ' ').trim();
 
 export const getSpeechRecognitionConstructor = () => {
@@ -18,15 +20,35 @@ export const getSpeechInputLabel = (mode) => {
       return 'On-device speech';
     case 'browser':
       return 'Browser speech';
+    case 'whisper':
+      return 'On-device Whisper';
     default:
       return 'Speech input unavailable';
   }
 };
 
+const hasMediaRecorderSupport = () =>
+  typeof window !== 'undefined' &&
+  typeof window.MediaRecorder === 'function' &&
+  typeof window.OfflineAudioContext === 'function' &&
+  Boolean(window.AudioContext || window.webkitAudioContext) &&
+  Boolean(navigator?.mediaDevices?.getUserMedia);
+
 export const detectSpeechRecognitionSupport = async (language = 'en-US') => {
   const SpeechRecognition = getSpeechRecognitionConstructor();
 
   if (!SpeechRecognition) {
+    if (hasMediaRecorderSupport()) {
+      return {
+        supported: true,
+        mode: 'whisper',
+        label: getSpeechInputLabel('whisper'),
+        onDeviceAvailability: 'unsupported',
+        canInstall: false,
+        canProcessLocally: true
+      };
+    }
+
     return {
       supported: false,
       mode: 'unsupported',
@@ -230,3 +252,358 @@ export class BrowserSpeechRecognitionSession {
     this.isActive = false;
   }
 }
+
+let transcriberPromise = null;
+
+const loadWhisperPipeline = async ({ progressCallback = null } = {}) => {
+  if (transcriberPromise) {
+    return transcriberPromise;
+  }
+
+  transcriberPromise = (async () => {
+    const { pipeline } = await import('@huggingface/transformers');
+    const device = typeof navigator !== 'undefined' && navigator.gpu ? 'webgpu' : 'wasm';
+    const dtype = device === 'webgpu' ? 'fp32' : 'q8';
+
+    return pipeline('automatic-speech-recognition', WHISPER_MODEL_ID, {
+      device,
+      dtype,
+      progress_callback: (event) => {
+        progressCallback?.(event);
+      }
+    });
+  })().catch((error) => {
+    transcriberPromise = null;
+    throw error;
+  });
+
+  return transcriberPromise;
+};
+
+export const preloadWhisperRecognition = (options) => loadWhisperPipeline(options);
+
+const decodeBlobToMono16k = async (blob) => {
+  const ContextClass = window.AudioContext || window.webkitAudioContext;
+
+  if (!ContextClass || typeof window.OfflineAudioContext !== 'function') {
+    throw new Error('Audio decoding is not supported in this browser.');
+  }
+
+  const arrayBuffer = await blob.arrayBuffer();
+  const decodeContext = new ContextClass();
+
+  let decoded;
+  try {
+    decoded = await decodeContext.decodeAudioData(arrayBuffer.slice(0));
+  } finally {
+    if (typeof decodeContext.close === 'function') {
+      decodeContext.close();
+    }
+  }
+
+  const targetSampleRate = 16000;
+  const frameCount = Math.max(1, Math.ceil(decoded.duration * targetSampleRate));
+  const offline = new window.OfflineAudioContext(1, frameCount, targetSampleRate);
+  const source = offline.createBufferSource();
+  source.buffer = decoded;
+  source.connect(offline.destination);
+  source.start(0);
+  const rendered = await offline.startRendering();
+
+  return rendered.getChannelData(0);
+};
+
+const pickRecorderMimeType = () => {
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/ogg;codecs=opus',
+    'audio/mp4'
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof MediaRecorder.isTypeSupported === 'function' && MediaRecorder.isTypeSupported(candidate)) {
+      return candidate;
+    }
+  }
+
+  return '';
+};
+
+export class WhisperSpeechRecognitionSession {
+  constructor({
+    language = 'en-US',
+    onStart = null,
+    onTranscription = null,
+    onEnd = null,
+    onError = null,
+    onProcessing = null,
+    onModelProgress = null
+  } = {}) {
+    this.language = language;
+    this.onStart = onStart;
+    this.onTranscription = onTranscription;
+    this.onEnd = onEnd;
+    this.onError = onError;
+    this.onProcessing = onProcessing;
+    this.onModelProgress = onModelProgress;
+
+    this.mode = 'whisper';
+    this.mediaRecorder = null;
+    this.mediaStream = null;
+    this.chunks = [];
+    this.mimeType = '';
+    this.isActive = false;
+    this.aborted = false;
+    this.lastError = null;
+    this.transcript = '';
+  }
+
+  async start() {
+    if (this.isActive) {
+      return { mode: this.mode, label: getSpeechInputLabel(this.mode) };
+    }
+
+    if (!hasMediaRecorderSupport()) {
+      const error = new Error('Microphone recording is not supported in this browser.');
+      error.code = 'no-media-recorder';
+      this.lastError = error;
+      this.onError?.(error, { mode: this.mode });
+      throw error;
+    }
+
+    this.aborted = false;
+    this.lastError = null;
+    this.transcript = '';
+    this.chunks = [];
+
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+      const message = error?.name === 'NotAllowedError'
+        ? 'Microphone access denied. Please allow microphone access in your browser settings.'
+        : error?.message || 'Unable to access microphone.';
+      const wrapped = new Error(message);
+      wrapped.code = error?.name === 'NotAllowedError' ? 'not-allowed' : 'mic-error';
+      this.lastError = wrapped;
+      this.onError?.(wrapped, { mode: this.mode });
+      throw wrapped;
+    }
+
+    this.mediaStream = stream;
+    this.mimeType = pickRecorderMimeType();
+
+    let recorder;
+    try {
+      recorder = this.mimeType
+        ? new MediaRecorder(stream, { mimeType: this.mimeType })
+        : new MediaRecorder(stream);
+    } catch (error) {
+      this._releaseStream();
+      const wrapped = new Error(error?.message || 'Unable to start audio recorder.');
+      wrapped.code = 'recorder-init';
+      this.lastError = wrapped;
+      this.onError?.(wrapped, { mode: this.mode });
+      throw wrapped;
+    }
+
+    this.mediaRecorder = recorder;
+
+    return new Promise((resolve, reject) => {
+      let started = false;
+
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) {
+          this.chunks.push(event.data);
+        }
+      };
+
+      recorder.onstart = () => {
+        started = true;
+        this.isActive = true;
+        this.onStart?.({ mode: this.mode, label: getSpeechInputLabel(this.mode) });
+        resolve({ mode: this.mode, label: getSpeechInputLabel(this.mode) });
+      };
+
+      recorder.onerror = (event) => {
+        const wrapped = new Error(event?.error?.message || 'Audio recording failed.');
+        wrapped.code = event?.error?.name || 'recorder-error';
+        this.lastError = wrapped;
+        this.onError?.(wrapped, { mode: this.mode });
+
+        if (!started) {
+          reject(wrapped);
+        }
+      };
+
+      recorder.onstop = () => {
+        this._handleStop();
+      };
+
+      try {
+        recorder.start();
+      } catch (error) {
+        this._releaseStream();
+        this.mediaRecorder = null;
+        reject(error);
+      }
+    });
+  }
+
+  stop() {
+    if (this.mediaRecorder && this.mediaRecorder.state === 'recording') {
+      try {
+        this.mediaRecorder.stop();
+      } catch (error) {
+        console.warn('[whisper] failed to stop recorder:', error);
+      }
+    }
+  }
+
+  abort() {
+    this.aborted = true;
+    if (this.mediaRecorder && this.mediaRecorder.state === 'recording') {
+      try {
+        this.mediaRecorder.stop();
+      } catch (error) {
+        console.warn('[whisper] failed to stop recorder:', error);
+      }
+    } else {
+      this._releaseStream();
+      this.mediaRecorder = null;
+    }
+    this.isActive = false;
+  }
+
+  async _handleStop() {
+    this.isActive = false;
+    this._releaseStream();
+
+    if (this.aborted) {
+      this.onEnd?.({
+        mode: this.mode,
+        label: getSpeechInputLabel(this.mode),
+        transcript: '',
+        error: this.lastError
+      });
+      this.mediaRecorder = null;
+      return;
+    }
+
+    if (!this.chunks.length) {
+      const error = new Error('No speech detected.');
+      error.code = 'no-speech';
+      this.lastError = error;
+      this.onEnd?.({
+        mode: this.mode,
+        label: getSpeechInputLabel(this.mode),
+        transcript: '',
+        error
+      });
+      this.mediaRecorder = null;
+      return;
+    }
+
+    this.onProcessing?.({ mode: this.mode, status: 'transcribing' });
+
+    try {
+      const blob = new Blob(this.chunks, { type: this.mimeType || 'audio/webm' });
+      const audio = await decodeBlobToMono16k(blob);
+
+      if (this.aborted) {
+        this.onEnd?.({
+          mode: this.mode,
+          label: getSpeechInputLabel(this.mode),
+          transcript: '',
+          error: this.lastError
+        });
+        this.mediaRecorder = null;
+        return;
+      }
+
+      const transcriber = await loadWhisperPipeline({
+        progressCallback: this.onModelProgress
+      });
+
+      if (this.aborted) {
+        this.onEnd?.({
+          mode: this.mode,
+          label: getSpeechInputLabel(this.mode),
+          transcript: '',
+          error: this.lastError
+        });
+        this.mediaRecorder = null;
+        return;
+      }
+
+      const result = await transcriber(audio, {
+        chunk_length_s: 30,
+        stride_length_s: 5,
+        return_timestamps: false
+      });
+
+      const text = normalizeTranscript(
+        Array.isArray(result) ? result.map((entry) => entry?.text || '').join(' ') : result?.text || ''
+      );
+
+      this.transcript = text;
+
+      if (text) {
+        this.onTranscription?.({
+          mode: this.mode,
+          label: getSpeechInputLabel(this.mode),
+          transcript: text,
+          finalTranscript: text,
+          interimTranscript: ''
+        });
+      } else {
+        const noSpeech = new Error('No speech detected.');
+        noSpeech.code = 'no-speech';
+        this.lastError = noSpeech;
+      }
+
+      this.onEnd?.({
+        mode: this.mode,
+        label: getSpeechInputLabel(this.mode),
+        transcript: text,
+        error: this.lastError
+      });
+    } catch (error) {
+      const wrapped = error instanceof Error
+        ? error
+        : new Error(typeof error === 'string' ? error : 'Whisper transcription failed.');
+      if (!wrapped.code) {
+        wrapped.code = 'whisper-error';
+      }
+      this.lastError = wrapped;
+      this.onError?.(wrapped, { mode: this.mode });
+      this.onEnd?.({
+        mode: this.mode,
+        label: getSpeechInputLabel(this.mode),
+        transcript: '',
+        error: wrapped
+      });
+    } finally {
+      this.mediaRecorder = null;
+    }
+  }
+
+  _releaseStream() {
+    this.mediaStream?.getTracks().forEach((track) => {
+      try {
+        track.stop();
+      } catch (_error) {
+        // ignore
+      }
+    });
+    this.mediaStream = null;
+  }
+}
+
+export const createSpeechRecognitionSession = (mode, options) => {
+  if (mode === 'whisper') {
+    return new WhisperSpeechRecognitionSession(options);
+  }
+  return new BrowserSpeechRecognitionSession(options);
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -81,7 +81,8 @@ export default defineConfig(({ mode }) => {
       headers: {
         'Content-Security-Policy': [
           "default-src 'self' https://73.118.140.130:3000;",
-          "script-src 'self' 'unsafe-inline' 'unsafe-eval';",
+          "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net;",
+          "worker-src 'self' blob:;",
           "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;",
           "img-src 'self' data: blob: https://*.googleusercontent.com https://images.unsplash.com https://image.pollinations.ai https://loremflickr.com https://picsum.photos;",
           "font-src 'self' data: https://fonts.gstatic.com;",


### PR DESCRIPTION
## Summary
- Live mode's mic input relied on the Web Speech API, which Firefox and Safari don't ship — those users would tap the mic, see no error feedback, and be unable to start a conversation. This adds a `MediaRecorder` + on-device Whisper fallback so voice input works on every modern browser.
- A dashed disclaimer appears under the orb when the fallback is active, explaining that the first recording downloads a ~40 MB model and may feel slow.

## What changed
- **`frontend/src/services/browserSpeechRecognition.js`** — new `WhisperSpeechRecognitionSession` class with the same callback interface (`onStart`/`onTranscription`/`onEnd`/`onError` plus `onProcessing`/`onModelProgress`). Records via `MediaRecorder`, decodes to 16 kHz mono with `OfflineAudioContext`, and transcribes via `@huggingface/transformers` Whisper (`Xenova/whisper-tiny.en`, q8). `detectSpeechRecognitionSupport` advertises `mode: 'whisper'` whenever the native API is missing but `MediaRecorder` is available; new `createSpeechRecognitionSession(mode, opts)` factory picks the right class.
- **`frontend/src/components/LiveModeUI.jsx`** — uses the factory, surfaces a new `transcribing` status while Whisper is processing, drives the loading bar from Whisper model-download progress on the first record, and renders a `Disclaimer` banner when `speechMode === 'whisper'`.
- **`frontend/vite.config.js`** — widens the dev CSP. transformers.js dynamically \`import()\`s its ONNX runtime EP module from \`cdn.jsdelivr.net\`, so \`script-src\` now includes that origin + \`'wasm-unsafe-eval'\`, and \`worker-src 'self' blob:\` is added for ORT's blob-URL workers. Without this, the dynamic module import is blocked even though \`connect-src\` allows the same origin for fetch.
- **\`frontend/package.json\`** — pins \`@huggingface/transformers ^3.8.1\` directly (was already hoisted transitively via \`kokoro-js\`, now explicit so Vite/npm resolution stays stable if \`kokoro-js\` ever drops the dep).

## Reviewer notes
- The Whisper model is downloaded lazily on the first mic press, not on Live Mode mount, so users who never speak don't pay the bandwidth cost.
- Whisper is on-device (WebGPU when available, WASM q8 otherwise) so no audio leaves the browser.
- Bundle impact is small at build time — the heavy bits are dynamically imported and the model files come from the HF CDN at runtime.
- Verified locally that the pipeline imports, downloads the model, and transcribes a synthesized buffer end-to-end with the new CSP. Native \`SpeechRecognition\` browsers are unaffected (existing path).
- Users running an existing dev server will need to restart it to pick up the new CSP, since CSP is applied to a document at load time.

## Test plan
- [ ] Open Live Mode in Firefox: confirm disclaimer appears, mic records, transcript flows into chat, Kokoro reads response back.
- [ ] Open Live Mode in Safari: same as above.
- [ ] Open Live Mode in Chrome/Edge: confirm no disclaimer, native \`SpeechRecognition\` path still used.
- [ ] First-record UX in Firefox: confirm the loading bar fills while the Whisper model downloads, and the orb status reads "Transcribing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)