### PR TITLE
Replace per-model rate limits with Pro/Lite/Image/Video tier system

### DIFF
--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -101,6 +101,29 @@ export function listImageModels() {
 }
 
 /**
+ * Get available video models (names)
+ */
+export function listVideoModels() {
+  const models = [];
+  const videoDefault = modelsConfig.video?.default;
+
+  for (const [provider, config] of Object.entries(modelsConfig.video || {})) {
+    if (provider === 'default') continue;
+
+    for (const [name, apiId] of Object.entries(config.models || {})) {
+      models.push({
+        id: name,
+        apiId: apiId,
+        provider,
+        isDefault: name === videoDefault
+      });
+    }
+  }
+
+  return models;
+}
+
+/**
  * Get default image model API ID for a provider
  */
 export function getDefaultImageModel(provider) {

--- a/backend/src/config/models.json
+++ b/backend/src/config/models.json
@@ -156,5 +156,14 @@
         "gpt-image": "gpt-image-1"
       }
     }
+  },
+
+  "video": {
+    "default": "sora-2",
+    "openai": {
+      "models": {
+        "sora-2": "sora-2"
+      }
+    }
   }
 }

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -11,6 +11,7 @@ import { parseAllowedOrigins } from '../middleware/cors.js';
 import { authLoginRateLimit, authRegisterRateLimit } from '../middleware/rateLimit.js';
 import { addUserSessionIndex, findUserByEmail, findUserByOAuthAccount, removeUserSessionIndex } from '../utils/helpers.js';
 import { createPkceChallenge, createSignedToken, generatePkceVerifier, generateRandomToken, getOAuthProviderConfig, isSupportedOAuthProvider, verifySignedToken } from '../utils/oauth.js';
+import { getGlobalUsageLimits, peekUserTierRateLimits } from '../utils/usageLimits.js';
 
 const auth = new Hono();
 const MAX_PASSWORD_LENGTH = 128;
@@ -859,6 +860,25 @@ auth.get('/me', requireAuth, async (c) => {
     success: true,
     data: { user: sanitizeUser(user) }
   });
+});
+
+/**
+ * Get current user's tier rate-limit consumption (without incrementing).
+ * Powers the "rate limits remaining" panel in the profile dropdown.
+ * GET /api/auth/usage/rate-limits
+ */
+auth.get('/usage/rate-limits', requireAuth, async (c) => {
+  const kv = c.env.KV;
+  const user = c.get('user');
+
+  if (!kv) {
+    return c.json({ error: 'Storage not configured' }, 500);
+  }
+
+  const limits = await getGlobalUsageLimits(kv);
+  const { buckets } = await peekUserTierRateLimits({ kv, userId: user.id, limits });
+
+  return c.json({ success: true, data: { buckets } });
 });
 
 /**

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -17,7 +17,7 @@ import { validateToolsForProvider } from '../config/index.js';
 import { applyPlatformSystemPrompt } from '../config/systemPrompt.js';
 import { requireAuthAndApproved } from '../middleware/auth.js';
 import { chatGenerationRateLimit } from '../middleware/rateLimit.js';
-import { evaluateModelRateLimits, evaluateUsageRequest, getGlobalUsageLimits, incrementUserUsage } from '../utils/usageLimits.js';
+import { evaluateTierRateLimit, evaluateUsageRequest, getGlobalUsageLimits, incrementUserUsage } from '../utils/usageLimits.js';
 
 const chat = new Hono();
 
@@ -133,26 +133,28 @@ chat.post('/chat/completions', chatGenerationRateLimit, async (c) => {
       }, 429);
     }
 
-    const modelRateEvaluation = await evaluateModelRateLimits({
+    const tierRateEvaluation = await evaluateTierRateLimit({
       kv,
       userId: user.id,
       modelId,
+      kind: 'chat',
       limits: usageLimits
     });
 
-    if (!modelRateEvaluation.allowed) {
-      c.header('Retry-After', String(modelRateEvaluation.blockingRule.retryAfterSeconds));
+    if (!tierRateEvaluation.allowed) {
+      c.header('Retry-After', String(tierRateEvaluation.rule.retryAfterSeconds));
       return c.json({
-        error: modelRateEvaluation.message,
-        code: 'model_rate_limit_exceeded',
-        model: modelRateEvaluation.modelId,
-        limit: modelRateEvaluation.blockingRule.limit,
-        windowSeconds: modelRateEvaluation.blockingRule.windowSeconds,
-        used: modelRateEvaluation.blockingRule.used,
-        remaining: modelRateEvaluation.blockingRule.remaining,
-        resetAt: modelRateEvaluation.blockingRule.resetAt,
-        retryAfterSeconds: modelRateEvaluation.blockingRule.retryAfterSeconds,
-        rules: modelRateEvaluation.rules
+        error: tierRateEvaluation.message,
+        code: 'tier_rate_limit_exceeded',
+        model: tierRateEvaluation.modelId,
+        tier: tierRateEvaluation.tier,
+        tierLabel: tierRateEvaluation.rule.label,
+        limit: tierRateEvaluation.rule.limit,
+        windowSeconds: tierRateEvaluation.rule.windowSeconds,
+        used: tierRateEvaluation.rule.used,
+        remaining: tierRateEvaluation.rule.remaining,
+        resetAt: tierRateEvaluation.rule.resetAt,
+        retryAfterSeconds: tierRateEvaluation.rule.retryAfterSeconds
       }, 429);
     }
 

--- a/backend/src/routes/image.js
+++ b/backend/src/routes/image.js
@@ -14,7 +14,7 @@ import { listImageModels } from '../config/index.js';
 import modelsConfig from '../config/models.json';
 import { requireAuthAndApproved } from '../middleware/auth.js';
 import { imageGenerationRateLimit } from '../middleware/rateLimit.js';
-import { evaluateModelRateLimits, evaluateUsageRequest, getGlobalUsageLimits, incrementUserUsage } from '../utils/usageLimits.js';
+import { evaluateTierRateLimit, evaluateUsageRequest, getGlobalUsageLimits, incrementUserUsage } from '../utils/usageLimits.js';
 
 const image = new Hono();
 
@@ -58,19 +58,20 @@ const getImageRateLimitModelId = (model, selectedProvider, resolvedApiId) => {
   return Object.keys(providerConfig?.models || {})[0] || resolvedApiId || 'image-default';
 };
 
-const modelRateLimitResponse = (c, evaluation) => {
-  c.header('Retry-After', String(evaluation.blockingRule.retryAfterSeconds));
+const tierRateLimitResponse = (c, evaluation) => {
+  c.header('Retry-After', String(evaluation.rule.retryAfterSeconds));
   return c.json({
     error: evaluation.message,
-    code: 'model_rate_limit_exceeded',
+    code: 'tier_rate_limit_exceeded',
     model: evaluation.modelId,
-    limit: evaluation.blockingRule.limit,
-    windowSeconds: evaluation.blockingRule.windowSeconds,
-    used: evaluation.blockingRule.used,
-    remaining: evaluation.blockingRule.remaining,
-    resetAt: evaluation.blockingRule.resetAt,
-    retryAfterSeconds: evaluation.blockingRule.retryAfterSeconds,
-    rules: evaluation.rules
+    tier: evaluation.tier,
+    tierLabel: evaluation.rule.label,
+    limit: evaluation.rule.limit,
+    windowSeconds: evaluation.rule.windowSeconds,
+    used: evaluation.rule.used,
+    remaining: evaluation.rule.remaining,
+    resetAt: evaluation.rule.resetAt,
+    retryAfterSeconds: evaluation.rule.retryAfterSeconds
   }, 429);
 };
 
@@ -132,15 +133,16 @@ image.post('/generate', imageGenerationRateLimit, async (c) => {
       }, 429);
     }
 
-    const modelRateEvaluation = await evaluateModelRateLimits({
+    const tierRateEvaluation = await evaluateTierRateLimit({
       kv,
       userId: user.id,
       modelId: rateLimitModelId,
+      kind: 'image',
       limits: usageLimits
     });
 
-    if (!modelRateEvaluation.allowed) {
-      return modelRateLimitResponse(c, modelRateEvaluation);
+    if (!tierRateEvaluation.allowed) {
+      return tierRateLimitResponse(c, tierRateEvaluation);
     }
 
     console.log(`Image generation: provider=${selectedProvider}, model=${model || 'default'}, apiId=${resolvedApiId}`);
@@ -276,15 +278,16 @@ image.post('/edit', imageGenerationRateLimit, async (c) => {
       }, 429);
     }
 
-    const modelRateEvaluation = await evaluateModelRateLimits({
+    const tierRateEvaluation = await evaluateTierRateLimit({
       kv,
       userId: user.id,
       modelId: rateLimitModelId,
+      kind: 'image',
       limits: usageLimits
     });
 
-    if (!modelRateEvaluation.allowed) {
-      return modelRateLimitResponse(c, modelRateEvaluation);
+    if (!tierRateEvaluation.allowed) {
+      return tierRateLimitResponse(c, tierRateEvaluation);
     }
 
     const result = await editImageWithDALLE(imageData, prompt, apiKey, {

--- a/backend/src/routes/video.js
+++ b/backend/src/routes/video.js
@@ -10,7 +10,8 @@ import { requireAuthAndApproved } from '../middleware/auth.js';
 import { videoGenerationRateLimit } from '../middleware/rateLimit.js';
 import { validateOutboundUrl } from '../utils/urlValidation.js';
 import { canUserAccessVideo, createVideoOwnershipRecord, getVideoOwnershipRecord } from '../utils/videoOwnership.js';
-import { evaluateModelRateLimits, evaluateUsageRequest, getGlobalUsageLimits, incrementUserUsage } from '../utils/usageLimits.js';
+import { evaluateTierRateLimit, evaluateUsageRequest, getGlobalUsageLimits, incrementUserUsage } from '../utils/usageLimits.js';
+import { listVideoModels } from '../config/index.js';
 
 const video = new Hono();
 const VIDEO_DOWNLOAD_HOST_ALLOWLIST = [
@@ -24,19 +25,20 @@ const VIDEO_DOWNLOAD_HOST_ALLOWLIST = [
 
 const isRedirectStatus = (status) => status >= 300 && status < 400;
 
-const modelRateLimitResponse = (c, evaluation) => {
-  c.header('Retry-After', String(evaluation.blockingRule.retryAfterSeconds));
+const tierRateLimitResponse = (c, evaluation) => {
+  c.header('Retry-After', String(evaluation.rule.retryAfterSeconds));
   return c.json({
     error: evaluation.message,
-    code: 'model_rate_limit_exceeded',
+    code: 'tier_rate_limit_exceeded',
     model: evaluation.modelId,
-    limit: evaluation.blockingRule.limit,
-    windowSeconds: evaluation.blockingRule.windowSeconds,
-    used: evaluation.blockingRule.used,
-    remaining: evaluation.blockingRule.remaining,
-    resetAt: evaluation.blockingRule.resetAt,
-    retryAfterSeconds: evaluation.blockingRule.retryAfterSeconds,
-    rules: evaluation.rules
+    tier: evaluation.tier,
+    tierLabel: evaluation.rule.label,
+    limit: evaluation.rule.limit,
+    windowSeconds: evaluation.rule.windowSeconds,
+    used: evaluation.rule.used,
+    remaining: evaluation.rule.remaining,
+    resetAt: evaluation.rule.resetAt,
+    retryAfterSeconds: evaluation.rule.retryAfterSeconds
   }, 429);
 };
 
@@ -62,12 +64,26 @@ const requireTrackedVideoAccess = async (c, videoId) => {
   return { error: null, record };
 };
 
-// Apply auth middleware to all video routes
-video.use('/*', requireAuthAndApproved);
+/**
+ * List available video models (public; needed by admin panel rate-limit assignment).
+ */
+video.get('/models', (c) => {
+  const models = listVideoModels();
+  return c.json({
+    models,
+    _note: 'Model list is defined in src/config/models.json'
+  });
+});
+
+// Apply auth selectively — /models is public.
+video.use('/generate', requireAuthAndApproved);
+video.use('/status', requireAuthAndApproved);
+video.use('/status/*', requireAuthAndApproved);
+video.use('/download', requireAuthAndApproved);
 
 /**
  * Generate video
- * 
+ *
  * POST /api/video/generate
  * Body:
  * - prompt: string (required)
@@ -117,15 +133,16 @@ video.post('/generate', videoGenerationRateLimit, async (c) => {
       }, 429);
     }
 
-    const modelRateEvaluation = await evaluateModelRateLimits({
+    const tierRateEvaluation = await evaluateTierRateLimit({
       kv,
       userId: user.id,
       modelId: model || 'sora-2',
+      kind: 'video',
       limits: usageLimits
     });
 
-    if (!modelRateEvaluation.allowed) {
-      return modelRateLimitResponse(c, modelRateEvaluation);
+    if (!tierRateEvaluation.allowed) {
+      return tierRateLimitResponse(c, tierRateEvaluation);
     }
 
     console.log('Sora video generation request received');

--- a/backend/src/utils/usageLimits.js
+++ b/backend/src/utils/usageLimits.js
@@ -1,10 +1,27 @@
 const USAGE_LIMITS_KEY = 'settings:usage-limits';
 
+export const TIER_NAMES = Object.freeze(['pro', 'lite', 'image', 'video']);
+export const TIER_LABELS = Object.freeze({
+  pro: 'Pro',
+  lite: 'Lite',
+  image: 'Image',
+  video: 'Video'
+});
+
+const DEFAULT_TIER_LIMIT = Object.freeze({ limit: null, windowSeconds: null });
+const DEFAULT_TIER_LIMITS = Object.freeze({
+  pro: { ...DEFAULT_TIER_LIMIT },
+  lite: { ...DEFAULT_TIER_LIMIT },
+  image: { ...DEFAULT_TIER_LIMIT },
+  video: { ...DEFAULT_TIER_LIMIT }
+});
+
 export const DEFAULT_USAGE_LIMITS = Object.freeze({
   turns: null,
   images: null,
   videos: null,
-  modelRateLimits: []
+  tiers: { ...DEFAULT_TIER_LIMITS },
+  modelTiers: {}
 });
 
 export const DEFAULT_USER_USAGE = Object.freeze({
@@ -16,7 +33,7 @@ export const DEFAULT_USER_USAGE = Object.freeze({
 });
 
 const USAGE_FIELDS = ['turns', 'images', 'videos'];
-const MODEL_RATE_LIMIT_MAX_WINDOW_SECONDS = 60 * 60 * 24 * 31;
+const TIER_MAX_WINDOW_SECONDS = 60 * 60 * 24 * 31;
 
 const normalizeCount = (value) => {
   const numericValue = Number(value);
@@ -49,6 +66,12 @@ const normalizePositiveInteger = (value) => {
   return numericValue;
 };
 
+const normalizeTierName = (value) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return TIER_NAMES.includes(trimmed) ? trimmed : null;
+};
+
 const normalizeModelId = (value) => {
   if (typeof value !== 'string') {
     return '';
@@ -57,70 +80,110 @@ const normalizeModelId = (value) => {
   return value.trim().slice(0, 200);
 };
 
-const normalizeRuleId = (value) => {
-  if (typeof value !== 'string') {
-    return '';
+const normalizeTierLimit = (rawTier) => {
+  const limit = normalizePositiveInteger(rawTier?.limit);
+  const windowSeconds = normalizePositiveInteger(rawTier?.windowSeconds);
+
+  if (limit === null || windowSeconds === null || windowSeconds > TIER_MAX_WINDOW_SECONDS) {
+    return { ...DEFAULT_TIER_LIMIT };
   }
 
-  return value.trim().replace(/[^a-zA-Z0-9:_-]/g, '-').slice(0, 120);
+  return { limit, windowSeconds };
 };
 
-const createModelRateLimitId = (modelId, limit, windowSeconds, index) => {
-  const safeModelId = modelId.replace(/[^a-zA-Z0-9:_-]/g, '-').slice(0, 80) || 'model';
-  return `${safeModelId}:${limit}:${windowSeconds}:${index}`;
+const normalizeTierLimits = (rawTiers = {}) => {
+  const out = {};
+  for (const tier of TIER_NAMES) {
+    out[tier] = normalizeTierLimit(rawTiers?.[tier]);
+  }
+  return out;
 };
 
-const normalizeModelRateLimitRule = (rawRule, index = 0, { strict = false } = {}) => {
-  const modelId = normalizeModelId(rawRule?.modelId ?? rawRule?.model);
-  const limit = normalizePositiveInteger(rawRule?.limit);
-  const windowSeconds = normalizePositiveInteger(rawRule?.windowSeconds);
-
-  if (!modelId) {
-    if (strict) throw new Error('Model rate limit rules need a model.');
-    return null;
+const parseTierLimitsInput = (rawTiers) => {
+  if (rawTiers === null || rawTiers === undefined) {
+    return undefined;
+  }
+  if (typeof rawTiers !== 'object') {
+    throw new Error('tiers must be an object keyed by tier name.');
   }
 
-  if (limit === null) {
-    if (strict) throw new Error(`Rate limit for ${modelId} must be a positive whole number.`);
-    return null;
-  }
-
-  if (windowSeconds === null || windowSeconds > MODEL_RATE_LIMIT_MAX_WINDOW_SECONDS) {
-    if (strict) throw new Error(`Rate limit window for ${modelId} must be between 1 second and 31 days.`);
-    return null;
-  }
-
-  const id = normalizeRuleId(rawRule?.id) || createModelRateLimitId(modelId, limit, windowSeconds, index);
-
-  return {
-    id,
-    modelId,
-    limit,
-    windowSeconds
-  };
-};
-
-export const normalizeModelRateLimits = (rawRules = []) => {
-  const sourceRules = Array.isArray(rawRules)
-    ? rawRules
-    : Object.entries(rawRules || {}).map(([modelId, rule]) => ({
-      ...(typeof rule === 'object' && rule !== null ? rule : {}),
-      modelId
-    }));
-  const seenIds = new Set();
-  const normalizedRules = [];
-
-  sourceRules.forEach((rule, index) => {
-    const normalizedRule = normalizeModelRateLimitRule(rule, index);
-    if (!normalizedRule || seenIds.has(normalizedRule.id)) {
-      return;
+  const parsed = {};
+  for (const tier of TIER_NAMES) {
+    const raw = rawTiers[tier];
+    if (raw === undefined) {
+      parsed[tier] = { ...DEFAULT_TIER_LIMIT };
+      continue;
     }
 
-    seenIds.add(normalizedRule.id);
-    normalizedRules.push(normalizedRule);
-  });
+    if (raw === null) {
+      parsed[tier] = { ...DEFAULT_TIER_LIMIT };
+      continue;
+    }
 
-  return normalizedRules;
+    const blank =
+      raw.limit === '' || raw.limit === null || raw.limit === undefined ||
+      raw.windowSeconds === '' || raw.windowSeconds === null || raw.windowSeconds === undefined;
+
+    if (blank) {
+      parsed[tier] = { ...DEFAULT_TIER_LIMIT };
+      continue;
+    }
+
+    const limit = normalizePositiveInteger(raw.limit);
+    if (limit === null) {
+      throw new Error(`Limit for the ${TIER_LABELS[tier]} tier must be a positive whole number.`);
+    }
+
+    const windowSeconds = normalizePositiveInteger(raw.windowSeconds);
+    if (windowSeconds === null || windowSeconds > TIER_MAX_WINDOW_SECONDS) {
+      throw new Error(`Window for the ${TIER_LABELS[tier]} tier must be between 1 second and 31 days.`);
+    }
+
+    parsed[tier] = { limit, windowSeconds };
+  }
+
+  return parsed;
+};
+
+const normalizeModelTiers = (rawMap = {}) => {
+  if (!rawMap || typeof rawMap !== 'object') {
+    return {};
+  }
+
+  const out = {};
+  for (const [rawModelId, rawTier] of Object.entries(rawMap)) {
+    const modelId = normalizeModelId(rawModelId);
+    const tier = normalizeTierName(rawTier);
+    if (!modelId || !tier) continue;
+    out[modelId] = tier;
+  }
+  return out;
+};
+
+const parseModelTiersInput = (rawMap) => {
+  if (rawMap === null || rawMap === undefined) {
+    return undefined;
+  }
+  if (typeof rawMap !== 'object') {
+    throw new Error('modelTiers must be an object keyed by model id.');
+  }
+
+  const out = {};
+  for (const [rawModelId, rawTier] of Object.entries(rawMap)) {
+    const modelId = normalizeModelId(rawModelId);
+    if (!modelId) continue;
+
+    if (rawTier === '' || rawTier === null || rawTier === undefined) {
+      continue;
+    }
+
+    const tier = normalizeTierName(rawTier);
+    if (!tier) {
+      throw new Error(`Unknown tier "${rawTier}" assigned to ${modelId}. Valid tiers: ${TIER_NAMES.join(', ')}.`);
+    }
+    out[modelId] = tier;
+  }
+  return out;
 };
 
 const normalizeTimestamp = (value) => {
@@ -136,7 +199,8 @@ export const normalizeUsageLimits = (rawLimits = {}) => ({
   turns: normalizeLimitValue(rawLimits.turns),
   images: normalizeLimitValue(rawLimits.images),
   videos: normalizeLimitValue(rawLimits.videos),
-  modelRateLimits: normalizeModelRateLimits(rawLimits.modelRateLimits)
+  tiers: normalizeTierLimits(rawLimits.tiers),
+  modelTiers: normalizeModelTiers(rawLimits.modelTiers)
 });
 
 export const parseUsageLimitsInput = (rawLimits = {}) => {
@@ -161,23 +225,18 @@ export const parseUsageLimitsInput = (rawLimits = {}) => {
     parsedLimits[field] = numericValue;
   }
 
-  if ('modelRateLimits' in rawLimits) {
-    const sourceRules = Array.isArray(rawLimits.modelRateLimits)
-      ? rawLimits.modelRateLimits
-      : Object.entries(rawLimits.modelRateLimits || {}).map(([modelId, rule]) => ({
-        ...(typeof rule === 'object' && rule !== null ? rule : {}),
-        modelId
-      }));
-    const seenIds = new Set();
+  if ('tiers' in rawLimits) {
+    const parsedTiers = parseTierLimitsInput(rawLimits.tiers);
+    if (parsedTiers !== undefined) {
+      parsedLimits.tiers = parsedTiers;
+    }
+  }
 
-    parsedLimits.modelRateLimits = sourceRules.map((rule, index) => {
-      const normalizedRule = normalizeModelRateLimitRule(rule, index, { strict: true });
-      if (seenIds.has(normalizedRule.id)) {
-        throw new Error(`Duplicate model rate limit rule id: ${normalizedRule.id}`);
-      }
-      seenIds.add(normalizedRule.id);
-      return normalizedRule;
-    });
+  if ('modelTiers' in rawLimits) {
+    const parsedTiers = parseModelTiersInput(rawLimits.modelTiers);
+    if (parsedTiers !== undefined) {
+      parsedLimits.modelTiers = parsedTiers;
+    }
   }
 
   return parsedLimits;
@@ -223,18 +282,15 @@ export const summarizeUsageTotals = (users = []) => {
 
 export const getGlobalUsageLimits = async (kv) => {
   if (!kv) {
-    return { ...DEFAULT_USAGE_LIMITS };
+    return { ...DEFAULT_USAGE_LIMITS, tiers: { ...DEFAULT_TIER_LIMITS }, modelTiers: {} };
   }
 
   try {
     const storedLimits = await kv.get(USAGE_LIMITS_KEY, 'json');
-    return {
-      ...DEFAULT_USAGE_LIMITS,
-      ...normalizeUsageLimits(storedLimits || {})
-    };
+    return normalizeUsageLimits(storedLimits || {});
   } catch (error) {
     console.error('Error reading usage limits:', error);
-    return { ...DEFAULT_USAGE_LIMITS };
+    return { ...DEFAULT_USAGE_LIMITS, tiers: { ...DEFAULT_TIER_LIMITS }, modelTiers: {} };
   }
 };
 
@@ -244,9 +300,12 @@ export const updateGlobalUsageLimits = async (kv, rawLimits = {}) => {
   }
 
   const currentLimits = await getGlobalUsageLimits(kv);
+  const parsed = parseUsageLimitsInput(rawLimits);
   const nextLimits = {
     ...currentLimits,
-    ...parseUsageLimitsInput(rawLimits)
+    ...parsed,
+    tiers: parsed.tiers ?? currentLimits.tiers,
+    modelTiers: parsed.modelTiers ?? currentLimits.modelTiers
   };
 
   await kv.put(USAGE_LIMITS_KEY, JSON.stringify(nextLimits));
@@ -299,75 +358,127 @@ export const evaluateUsageRequest = ({ user, limits, requested = {} }) => {
   };
 };
 
-const getMatchingModelRateLimitRules = (limits, modelId) => {
+const resolveTierForModel = (limits, modelId, kind) => {
   const normalizedModelId = normalizeModelId(modelId);
-  if (!normalizedModelId) {
-    return [];
+  const fromMap = limits?.modelTiers?.[normalizedModelId];
+  if (fromMap && TIER_NAMES.includes(fromMap)) {
+    return fromMap;
   }
-
-  return normalizeModelRateLimits(limits?.modelRateLimits).filter((rule) => rule.modelId === normalizedModelId);
+  if (kind === 'image' || kind === 'video') {
+    return kind;
+  }
+  return null;
 };
 
-export const evaluateModelRateLimits = async ({ kv, userId, modelId, limits }) => {
-  const rules = getMatchingModelRateLimitRules(limits, modelId);
-  if (!kv || !userId || rules.length === 0) {
+const tierStateKey = (tier, userId) => `ratelimit:tier:${tier}:user:${userId}`;
+
+export const evaluateTierRateLimit = async ({ kv, userId, modelId, kind, limits }) => {
+  const tier = resolveTierForModel(limits, modelId, kind);
+  const tierConfig = tier ? limits?.tiers?.[tier] : null;
+  const hasLimit = tierConfig && tierConfig.limit && tierConfig.windowSeconds;
+
+  if (!kv || !userId || !tier || !hasLimit) {
     return {
       allowed: true,
+      tier,
       modelId: normalizeModelId(modelId),
-      rules: []
+      rule: null
     };
   }
 
   const now = Date.now();
-  const evaluatedRules = [];
+  const key = tierStateKey(tier, userId);
+  const windowMs = tierConfig.windowSeconds * 1000;
+  let state = await kv.get(key, 'json');
 
-  for (const rule of rules) {
-    const key = `ratelimit:model:${rule.id}:user:${userId}`;
-    const windowMs = rule.windowSeconds * 1000;
-    let state = await kv.get(key, 'json');
-
-    if (!state || typeof state.resetAt !== 'number' || state.resetAt <= now || state.windowSeconds !== rule.windowSeconds) {
-      state = {
-        count: 0,
-        resetAt: now + windowMs,
-        windowSeconds: rule.windowSeconds
-      };
-    }
-
-    state.count += 1;
-
-    const ttlSeconds = Math.max(1, Math.ceil((state.resetAt - now) / 1000));
-    await kv.put(key, JSON.stringify(state), { expirationTtl: ttlSeconds });
-
-    evaluatedRules.push({
-      ...rule,
-      used: state.count,
-      remaining: Math.max(0, rule.limit - state.count),
-      resetAt: new Date(state.resetAt).toISOString(),
-      retryAfterSeconds: ttlSeconds,
-      exceeded: state.count > rule.limit
-    });
+  if (
+    !state ||
+    typeof state.resetAt !== 'number' ||
+    state.resetAt <= now ||
+    state.windowSeconds !== tierConfig.windowSeconds
+  ) {
+    state = {
+      count: 0,
+      resetAt: now + windowMs,
+      windowSeconds: tierConfig.windowSeconds
+    };
   }
 
-  const exceededRules = evaluatedRules.filter((rule) => rule.exceeded);
-  if (exceededRules.length > 0) {
-    exceededRules.sort((a, b) => b.retryAfterSeconds - a.retryAfterSeconds);
-    const blockingRule = exceededRules[0];
+  state.count += 1;
 
+  const ttlSeconds = Math.max(1, Math.ceil((state.resetAt - now) / 1000));
+  await kv.put(key, JSON.stringify(state), { expirationTtl: ttlSeconds });
+
+  const rule = {
+    tier,
+    label: TIER_LABELS[tier],
+    limit: tierConfig.limit,
+    windowSeconds: tierConfig.windowSeconds,
+    used: state.count,
+    remaining: Math.max(0, tierConfig.limit - state.count),
+    resetAt: new Date(state.resetAt).toISOString(),
+    retryAfterSeconds: ttlSeconds,
+    exceeded: state.count > tierConfig.limit
+  };
+
+  if (rule.exceeded) {
     return {
       allowed: false,
+      tier,
       modelId: normalizeModelId(modelId),
-      blockingRule,
-      rules: evaluatedRules,
-      message: `This account has reached the rate limit for ${blockingRule.modelId}. Try again after ${blockingRule.resetAt}.`
+      rule,
+      message: `This account has reached the rate limit for the ${TIER_LABELS[tier]} tier. Try again after ${rule.resetAt}.`
     };
   }
 
   return {
     allowed: true,
+    tier,
     modelId: normalizeModelId(modelId),
-    rules: evaluatedRules
+    rule
   };
+};
+
+export const peekUserTierRateLimits = async ({ kv, userId, limits }) => {
+  const normalizedLimits = normalizeUsageLimits(limits || {});
+  const buckets = [];
+
+  for (const tier of TIER_NAMES) {
+    const config = normalizedLimits.tiers?.[tier] || { ...DEFAULT_TIER_LIMIT };
+    let used = 0;
+    let resetAt = null;
+    let windowSeconds = config.windowSeconds || null;
+
+    if (kv && userId && config.limit && config.windowSeconds) {
+      const state = await kv.get(tierStateKey(tier, userId), 'json');
+      const now = Date.now();
+      if (
+        state &&
+        typeof state.resetAt === 'number' &&
+        state.resetAt > now &&
+        state.windowSeconds === config.windowSeconds
+      ) {
+        used = normalizeCount(state.count);
+        resetAt = new Date(state.resetAt).toISOString();
+      } else {
+        used = 0;
+        resetAt = null;
+      }
+    }
+
+    buckets.push({
+      tier,
+      label: TIER_LABELS[tier],
+      limit: config.limit ?? null,
+      windowSeconds,
+      used,
+      remaining: config.limit ? Math.max(0, config.limit - used) : null,
+      resetAt,
+      configured: !!(config.limit && config.windowSeconds)
+    });
+  }
+
+  return { buckets };
 };
 
 const persistUserUsage = async (kv, userId, transformUsage) => {

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import ModelIcon from './ModelIcon'; // Assuming ModelIcon is correctly imported
 import { NavLink as RouterNavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from '../contexts/TranslationContext';
 import { createSharedChat, getSharedChatUrl } from '../services/shareService';
+import { getUserRateLimits } from '../services/authService';
 
 // Styled Components - Updated for Grok.com-inspired design
 const SidebarContainer = styled.div.attrs({ 'data-shadow': 'sidebar' })`
@@ -841,6 +842,70 @@ const ProfileDropdownItem = styled.button`
   }
 `;
 
+const RateLimitsToggle = styled.button`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  color: ${props => props.theme.name === 'lakeside' ? 'rgb(232, 196, 138)' : props.theme.text};
+  font-size: var(--font-size, 1rem);
+  font-weight: 400;
+  cursor: pointer;
+  font-family: ${props => props.theme?.fontFamily || 'var(--font-family)'};
+  text-align: left;
+  justify-content: flex-start;
+
+  &:hover {
+    background: ${props => props.theme.name === 'dark' ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)'};
+  }
+
+  > svg.icon {
+    margin-right: 8px;
+    width: 16px;
+    height: 16px;
+    opacity: 0.7;
+    flex-shrink: 0;
+    color: ${props => props.theme.name === 'lakeside' ? 'rgb(232, 196, 138)' : 'currentColor'};
+  }
+
+  > svg.chevron {
+    margin-left: auto;
+    width: 14px;
+    height: 14px;
+    opacity: 0.55;
+    flex-shrink: 0;
+    transition: transform 0.18s ease;
+    transform: ${props => props.$open ? 'rotate(180deg)' : 'rotate(0deg)'};
+  }
+`;
+
+const RateLimitItem = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  color: ${props => props.theme.name === 'lakeside' ? 'rgb(232, 196, 138)' : props.theme.text};
+  font-size: var(--font-size, 1rem);
+  font-weight: 400;
+  font-family: ${props => props.theme?.fontFamily || 'var(--font-family)'};
+
+  > svg {
+    margin-right: 8px;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+  }
+`;
+
+const RateLimitMeta = styled.span`
+  margin-left: auto;
+  opacity: 0.62;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+`;
+
 const ProfileAvatar = styled.div`
   width: 16px;
   height: 16px;
@@ -860,6 +925,50 @@ const ProfileAvatar = styled.div`
 `;
 
 // --- React Component ---
+
+const Speedometer = ({ pct, tone }) => {
+  const cx = 8;
+  const cy = 13;
+  const r = 6.5;
+  const safePct = Math.max(0, Math.min(100, Number.isFinite(pct) ? pct : 0));
+  const angle = Math.PI * (1 - safePct / 100);
+  const fillEndX = cx + r * Math.cos(angle);
+  const fillEndY = cy - r * Math.sin(angle);
+  const needleX = cx + (r - 1.2) * Math.cos(angle);
+  const needleY = cy - (r - 1.2) * Math.sin(angle);
+  const fillColor = tone === 'danger' ? '#dc2626' : tone === 'warning' ? '#d97706' : '#059669';
+
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d={`M ${cx - r} ${cy} A ${r} ${r} 0 0 1 ${cx + r} ${cy}`} stroke="currentColor" strokeOpacity="0.22" strokeWidth="1.8" fill="none" strokeLinecap="round" />
+      {safePct > 0 && (
+        <path d={`M ${cx - r} ${cy} A ${r} ${r} 0 0 1 ${fillEndX.toFixed(2)} ${fillEndY.toFixed(2)}`} stroke={fillColor} strokeWidth="1.8" fill="none" strokeLinecap="round" />
+      )}
+      <line x1={cx} y1={cy} x2={needleX.toFixed(2)} y2={needleY.toFixed(2)} stroke={fillColor} strokeWidth="1.2" strokeLinecap="round" />
+      <circle cx={cx} cy={cy} r="1.1" fill={fillColor} />
+    </svg>
+  );
+};
+
+const formatRateLimitReset = (resetAt) => {
+  if (!resetAt) return null;
+  const date = new Date(resetAt);
+  if (Number.isNaN(date.getTime())) return null;
+  const diffMs = date.getTime() - Date.now();
+  if (diffMs <= 0) return 'now';
+  const totalMinutes = Math.round(diffMs / 60000);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const totalHours = Math.round(totalMinutes / 60);
+  if (totalHours < 48) return `${totalHours}h`;
+  const totalDays = Math.round(totalHours / 24);
+  return `${totalDays}d`;
+};
+
+const rateLimitTone = (pct) => {
+  if (pct >= 100) return 'danger';
+  if (pct >= 80) return 'warning';
+  return 'safe';
+};
 
 const Sidebar = ({
   chats = [], // Default to empty array
@@ -888,6 +997,13 @@ const Sidebar = ({
   const [showHamburger, setShowHamburger] = useState(true); // Show hamburger
   const [isModelDropdownOpen, setIsModelDropdownOpen] = useState(false);
   const [isProfileDropdownOpen, setIsProfileDropdownOpen] = useState(false);
+  const [isRateLimitsOpen, setIsRateLimitsOpen] = useState(true);
+  const [rateLimitBuckets, setRateLimitBuckets] = useState([
+    { tier: 'pro', label: 'Pro', limit: null, used: 0, remaining: null, resetAt: null, configured: false },
+    { tier: 'lite', label: 'Lite', limit: null, used: 0, remaining: null, resetAt: null, configured: false },
+    { tier: 'image', label: 'Image', limit: null, used: 0, remaining: null, resetAt: null, configured: false },
+    { tier: 'video', label: 'Video', limit: null, used: 0, remaining: null, resetAt: null, configured: false }
+  ]);
   const [copyStatus, setCopyStatus] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [profilePicture, setProfilePicture] = useState(
@@ -927,6 +1043,20 @@ const Sidebar = ({
       window.removeEventListener('profilePictureChanged', handleProfilePictureChange);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isProfileDropdownOpen || !isLoggedIn) return;
+    let cancelled = false;
+    getUserRateLimits()
+      .then((buckets) => {
+        if (cancelled) return;
+        if (Array.isArray(buckets) && buckets.length > 0) {
+          setRateLimitBuckets(buckets);
+        }
+      })
+      .catch(() => { /* keep current defaults if API fails */ });
+    return () => { cancelled = true; };
+  }, [isProfileDropdownOpen, isLoggedIn]);
 
   // Close dropdowns when clicking outside
   useEffect(() => {
@@ -1387,6 +1517,45 @@ const Sidebar = ({
 
                 {/* Profile Dropdown Menu */}
                 <ProfileDropdown $isOpen={isProfileDropdownOpen}>
+                  {isLoggedIn && rateLimitBuckets.length > 0 && (
+                    <>
+                      <RateLimitsToggle
+                        type="button"
+                        $open={isRateLimitsOpen}
+                        onClick={() => setIsRateLimitsOpen((open) => !open)}
+                        aria-expanded={isRateLimitsOpen}
+                      >
+                        <svg className="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M3 12a9 9 0 1 1 18 0"></path>
+                          <path d="M12 12l4-4"></path>
+                          <circle cx="12" cy="12" r="1.2" fill="currentColor"></circle>
+                        </svg>
+                        <span>Rate limits</span>
+                        <svg className="chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <polyline points="6 9 12 15 18 9"></polyline>
+                        </svg>
+                      </RateLimitsToggle>
+                      {isRateLimitsOpen && rateLimitBuckets.map((bucket) => {
+                        const used = Number(bucket.used) || 0;
+                        const limit = Number(bucket.limit) || 0;
+                        const isConfigured = bucket.configured && limit > 0;
+                        const remaining = isConfigured ? Math.max(0, limit - used) : 0;
+                        const pct = isConfigured ? (used / limit) * 100 : 0;
+                        const reset = formatRateLimitReset(bucket.resetAt);
+                        return (
+                          <RateLimitItem key={bucket.tier}>
+                            <Speedometer pct={pct} tone={isConfigured ? rateLimitTone(pct) : 'safe'} />
+                            <span>{bucket.label || bucket.tier}</span>
+                            <RateLimitMeta>
+                              {isConfigured
+                                ? `${remaining.toLocaleString('en-US')} left${reset ? ` · ${reset}` : ''}`
+                                : 'Unlimited'}
+                            </RateLimitMeta>
+                          </RateLimitItem>
+                        );
+                      })}
+                    </>
+                  )}
                   <ProfileDropdownItem onClick={handleSettingsClick}>
                     {isRetro ? (
                       retroIcon('/images/retroTheme/settingsIcon.png', 'Settings')

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -12,6 +12,7 @@ import {
   getArtifactChatConfig,
   getChatModels,
   getImageModels,
+  getVideoModels,
   updateArtifactChatConfig,
   updateDeepResearchConfig,
   updateUserDetails,
@@ -21,7 +22,29 @@ import AdminLoginModal from '../components/AdminLoginModal';
 
 const STATUS_LABELS = { active: 'Active', pending: 'Pending', suspended: 'Suspended', banned: 'Banned' };
 const ROLE_LABELS = { admin: 'Admin', user: 'User' };
-const DEFAULT_LIMITS = { turns: null, images: null, videos: null, modelRateLimits: [] };
+const TIER_KEYS = ['pro', 'lite', 'image', 'video'];
+const TIER_LABELS = { pro: 'Pro', lite: 'Lite', image: 'Image', video: 'Video' };
+const TIER_DESCRIPTIONS = {
+  pro: 'Higher-intelligence chat models you mark as Pro.',
+  lite: 'Faster / lighter chat models you mark as Lite.',
+  image: 'All image generation requests.',
+  video: 'All video generation requests.'
+};
+const EMPTY_TIER_LIMIT_FORM = { limit: '', windowAmount: '', windowUnit: 'hours' };
+const EMPTY_TIER_LIMIT_FORM_MAP = TIER_KEYS.reduce((acc, key) => {
+  acc[key] = { ...EMPTY_TIER_LIMIT_FORM };
+  return acc;
+}, {});
+const DEFAULT_LIMITS = {
+  turns: null,
+  images: null,
+  videos: null,
+  tiers: TIER_KEYS.reduce((acc, key) => {
+    acc[key] = { limit: null, windowSeconds: null };
+    return acc;
+  }, {}),
+  modelTiers: {}
+};
 const DEFAULT_DEEP_RESEARCH_CONFIG = {
   plannerModel: 'gemini-3.1-pro',
   researcherModel: 'gemini-3-flash',
@@ -62,9 +85,15 @@ const DEEP_RESEARCH_FORM_FIELD_KEYS = {
   requestTimeoutMs: 'requestTimeoutMs',
   allowWriterModelOverride: 'allowWriterModelOverride'
 };
-const EMPTY_LIMIT_FORM = { turns: '', images: '', videos: '', modelRateLimits: [] };
-const EMPTY_MODEL_RATE_DRAFT = { modelId: '', limit: '', windowAmount: '5', windowUnit: 'minutes' };
-const WINDOW_UNIT_SECONDS = { seconds: 1, minutes: 60, hours: 3600, days: 86400 };
+const EMPTY_LIMIT_FORM = {
+  turns: '',
+  images: '',
+  videos: '',
+  tiers: { ...EMPTY_TIER_LIMIT_FORM_MAP },
+  modelTiers: {}
+};
+const WINDOW_UNIT_SECONDS = { minutes: 60, hours: 3600, days: 86400, weeks: 604800 };
+const WINDOW_UNIT_LABELS = { minutes: 'Minutes', hours: 'Hours', days: 'Days', weeks: 'Weeks' };
 
 const Page = styled.div`
   flex: 1; min-height: 100vh; min-width: 0; color: ${p => p.theme.text}; overflow-y: auto; overflow-x: hidden;
@@ -142,22 +171,42 @@ const SnapshotGrid = styled.div`
   @media (max-width: 520px) { grid-template-columns:1fr; }
 `;
 const RateLimitSection = styled.div`
-  border:1px solid ${p => p.theme.border}; border-radius:12px; padding:14px; background:${p => p.theme.inputBackground || p.theme.background};
+  border:1px solid ${p => p.theme.border}; border-radius:12px; padding:16px; background:${p => p.theme.inputBackground || p.theme.background};
+  display:flex; flex-direction:column; gap:14px;
 `;
-const RateLimitFormGrid = styled.div`
-  display:grid; grid-template-columns:minmax(220px,1fr) 130px 130px 140px auto; gap:10px; align-items:end;
-  @media (max-width: 980px) { grid-template-columns:1fr 1fr; }
-  @media (max-width: 560px) { grid-template-columns:1fr; }
+const TierGrid = styled.div`
+  display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:12px;
+  @media (max-width: 720px) { grid-template-columns:1fr; }
 `;
-const RateRuleList = styled.div`display:flex; flex-direction:column; gap:8px; margin-top:12px;`;
-const RateRuleRow = styled.div`
-  display:grid; grid-template-columns:minmax(220px,1fr) 160px 180px auto; gap:10px; align-items:center; padding:10px;
-  border:1px solid ${p => p.theme.border}; border-radius:10px; background:${p => p.theme.sidebar};
-  @media (max-width: 760px) { grid-template-columns:1fr; }
+const TierCard = styled.div`
+  border:1px solid ${p => p.theme.border}; border-radius:12px; padding:14px;
+  background:${p => p.theme.sidebar};
+  display:flex; flex-direction:column; gap:10px;
 `;
-const RuleModel = styled.div`display:flex; flex-direction:column; gap:3px; min-width:0;`;
-const RuleModelId = styled.span`font-weight:700; font-size:0.9rem; overflow-wrap:anywhere;`;
-const RuleMeta = styled.span`font-size:0.78rem; opacity:0.66;`;
+const TierCardHead = styled.div`display:flex; justify-content:space-between; align-items:flex-start; gap:10px;`;
+const TierName = styled.div`font-size:0.96rem; font-weight:700; letter-spacing:-0.01em;`;
+const TierMeta = styled.div`font-size:0.78rem; opacity:0.7; line-height:1.4;`;
+const TierFieldRow = styled.div`
+  display:grid; grid-template-columns:minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr); gap:8px;
+`;
+const TierClearButton = styled.button`
+  background:none; border:none; cursor:pointer; padding:0; font-size:0.78rem;
+  color:${p => p.theme.text}; opacity:0.6; text-decoration:underline;
+  &:hover:not(:disabled){opacity:0.95;}
+  &:disabled{cursor:not-allowed; opacity:0.35;}
+`;
+const ModelTierGroup = styled.div`display:flex; flex-direction:column; gap:8px;`;
+const ModelTierGroupTitle = styled.div`font-size:0.78rem; opacity:0.65; letter-spacing:0.06em; text-transform:uppercase;`;
+const ModelTierList = styled.div`
+  display:grid; grid-template-columns:1fr 180px; gap:8px 12px; align-items:center;
+  @media (max-width: 600px) { grid-template-columns:1fr; }
+`;
+const ModelTierRow = styled.div`display:contents;`;
+const ModelTierLabel = styled.div`
+  display:flex; flex-direction:column; gap:2px; min-width:0; padding:6px 0;
+`;
+const ModelTierName = styled.span`font-size:0.9rem; font-weight:600; overflow-wrap:anywhere;`;
+const ModelTierMeta = styled.span`font-size:0.76rem; opacity:0.62;`;
 const Controls = styled.div`
   display:grid; grid-template-columns:minmax(220px,1fr) 180px 180px auto; gap:10px; margin-bottom:14px;
   @media (max-width: 980px) { grid-template-columns:1fr 1fr; }
@@ -298,49 +347,70 @@ const formatLimitValue = (value) => value === null || value === undefined ? 'Unl
 const formatUsageValue = (used, limit) => limit === null || limit === undefined ? `${used.toLocaleString('en-US')} used` : `${used.toLocaleString('en-US')} / ${limit.toLocaleString('en-US')}`;
 const getUsageTone = (used, limit) => { if (limit === null || limit === undefined) return 'neutral'; if (limit === 0) return used > 0 ? 'danger' : 'safe'; const ratio = used / limit; if (ratio >= 1) return 'danger'; if (ratio >= 0.8) return 'warning'; return 'safe'; };
 const getUsageProgress = (used, limit) => { if (limit === null || limit === undefined) return null; if (limit === 0) return used > 0 ? 100 : 0; return Math.max(0, Math.min(100, Math.round((used / limit) * 100))); };
-const normalizeModelRateLimits = (rules = []) => {
-  const sourceRules = Array.isArray(rules)
-    ? rules
-    : Object.entries(rules || {}).map(([modelId, rule]) => ({
-      ...(typeof rule === 'object' && rule !== null ? rule : {}),
-      modelId
-    }));
-  const seen = new Set();
-
-  return sourceRules.reduce((items, rule, index) => {
-    const modelId = typeof rule?.modelId === 'string' ? rule.modelId.trim() : '';
-    const limit = Number(rule?.limit);
-    const windowSeconds = Number(rule?.windowSeconds);
-    const id = typeof rule?.id === 'string' && rule.id.trim()
-      ? rule.id.trim()
-      : `${modelId.replace(/[^a-zA-Z0-9:_-]/g, '-')}-${limit}-${windowSeconds}-${index}`;
-
-    if (!modelId || !Number.isInteger(limit) || limit <= 0 || !Number.isInteger(windowSeconds) || windowSeconds <= 0 || seen.has(id)) {
-      return items;
-    }
-
-    seen.add(id);
-    items.push({ id, modelId, limit, windowSeconds });
-    return items;
-  }, []);
-};
 const DEFAULT_ARTIFACT_CHAT_CONFIG = {
   model: 'gpt-5.4-mini',
   provider: 'openai'
 };
-const normalizeLimits = (limits = {}) => ({ ...DEFAULT_LIMITS, ...limits, modelRateLimits: normalizeModelRateLimits(limits.modelRateLimits) });
+const normalizeTierLimits = (tiers = {}) => {
+  const out = {};
+  for (const key of TIER_KEYS) {
+    const raw = tiers?.[key] || {};
+    const limit = Number(raw.limit);
+    const windowSeconds = Number(raw.windowSeconds);
+    out[key] = {
+      limit: Number.isInteger(limit) && limit > 0 ? limit : null,
+      windowSeconds: Number.isInteger(windowSeconds) && windowSeconds > 0 ? windowSeconds : null
+    };
+  }
+  return out;
+};
+const normalizeModelTiers = (map = {}) => {
+  if (!map || typeof map !== 'object') return {};
+  const out = {};
+  for (const [modelId, tier] of Object.entries(map)) {
+    if (typeof modelId !== 'string' || !modelId.trim()) continue;
+    if (typeof tier !== 'string' || !TIER_KEYS.includes(tier)) continue;
+    out[modelId.trim()] = tier;
+  }
+  return out;
+};
+const normalizeLimits = (limits = {}) => ({
+  ...DEFAULT_LIMITS,
+  ...limits,
+  tiers: normalizeTierLimits(limits.tiers),
+  modelTiers: normalizeModelTiers(limits.modelTiers)
+});
+const pickWindowUnit = (windowSeconds) => {
+  if (!Number.isFinite(windowSeconds) || windowSeconds <= 0) return 'hours';
+  const candidates = ['weeks', 'days', 'hours', 'minutes'];
+  for (const unit of candidates) {
+    const unitSeconds = WINDOW_UNIT_SECONDS[unit];
+    if (windowSeconds % unitSeconds === 0) return unit;
+  }
+  return 'hours';
+};
+const tierFormFromLimit = ({ limit, windowSeconds }) => {
+  if (!limit || !windowSeconds) return { ...EMPTY_TIER_LIMIT_FORM };
+  const unit = pickWindowUnit(windowSeconds);
+  const amount = Math.max(1, Math.round(windowSeconds / WINDOW_UNIT_SECONDS[unit]));
+  return { limit: String(limit), windowAmount: String(amount), windowUnit: unit };
+};
 const syncLimitForm = (limits) => {
   const normalizedLimits = normalizeLimits(limits);
   return {
     turns: toLimitInput(normalizedLimits.turns),
     images: toLimitInput(normalizedLimits.images),
     videos: toLimitInput(normalizedLimits.videos),
-    modelRateLimits: normalizedLimits.modelRateLimits
+    tiers: TIER_KEYS.reduce((acc, key) => {
+      acc[key] = tierFormFromLimit(normalizedLimits.tiers[key] || {});
+      return acc;
+    }, {}),
+    modelTiers: { ...normalizedLimits.modelTiers }
   };
 };
 const getWindowSeconds = (amount, unit) => {
   const numericAmount = Number(amount);
-  const unitSeconds = WINDOW_UNIT_SECONDS[unit] || WINDOW_UNIT_SECONDS.minutes;
+  const unitSeconds = WINDOW_UNIT_SECONDS[unit] || WINDOW_UNIT_SECONDS.hours;
   if (!Number.isInteger(numericAmount) || numericAmount <= 0) return null;
   return numericAmount * unitSeconds;
 };
@@ -348,6 +418,7 @@ const formatDuration = (seconds) => {
   const value = Number(seconds);
   if (!Number.isFinite(value) || value <= 0) return 'unknown window';
   const units = [
+    ['week', 604800],
     ['day', 86400],
     ['hour', 3600],
     ['minute', 60],
@@ -356,6 +427,16 @@ const formatDuration = (seconds) => {
   const [label, size] = units.find(([, unitSeconds]) => value % unitSeconds === 0) || ['second', 1];
   const amount = value / size;
   return `${amount.toLocaleString('en-US')} ${label}${amount === 1 ? '' : 's'}`;
+};
+const tierForKind = (kind) => {
+  if (kind === 'image') return 'image';
+  if (kind === 'video') return 'video';
+  return 'lite';
+};
+const tiersAvailableForKind = (kind) => {
+  if (kind === 'image') return ['image'];
+  if (kind === 'video') return ['video'];
+  return ['pro', 'lite'];
 };
 
 const AdminPage = ({ collapsed }) => {
@@ -370,7 +451,7 @@ const AdminPage = ({ collapsed }) => {
   const [artifactChatConfigForm, setArtifactChatConfigForm] = useState(DEFAULT_ARTIFACT_CHAT_CONFIG);
   const [chatModels, setChatModels] = useState([]);
   const [imageModels, setImageModels] = useState([]);
-  const [modelRateDraft, setModelRateDraft] = useState(EMPTY_MODEL_RATE_DRAFT);
+  const [videoModels, setVideoModels] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [roleFilter, setRoleFilter] = useState('all');
@@ -394,14 +475,15 @@ const AdminPage = ({ collapsed }) => {
     setError('');
 
     try {
-      const [usersData, statsData, limitsData, deepResearchConfigData, artifactChatConfigData, chatModelData, imageModelData] = await Promise.all([
+      const [usersData, statsData, limitsData, deepResearchConfigData, artifactChatConfigData, chatModelData, imageModelData, videoModelData] = await Promise.all([
         getAllUsers(),
         getDashboardStats(),
         getUsageLimits(),
         getDeepResearchConfig(),
         getArtifactChatConfig(),
         getChatModels().catch(() => []),
-        getImageModels().catch(() => [])
+        getImageModels().catch(() => []),
+        getVideoModels().catch(() => [])
       ]);
       const nextUsers = (usersData || []).map(normalizeUser);
       const nextLimits = normalizeLimits(limitsData || statsData?.usageLimits || DEFAULT_LIMITS);
@@ -426,6 +508,7 @@ const AdminPage = ({ collapsed }) => {
       });
       setChatModels(Array.isArray(chatModelData) ? chatModelData : []);
       setImageModels(Array.isArray(imageModelData) ? imageModelData : []);
+      setVideoModels(Array.isArray(videoModelData) ? videoModelData : []);
       return nextUsers;
     } catch (err) {
       setError(err.message || 'Failed to load admin data.');
@@ -452,14 +535,9 @@ const AdminPage = ({ collapsed }) => {
 
     (Array.isArray(chatModels) ? chatModels : []).forEach((model) => addModel(model, 'chat'));
     (Array.isArray(imageModels) ? imageModels : []).forEach((model) => addModel(model, 'image'));
-    addModel({ id: 'sora-2', provider: 'openai' }, 'video');
+    (Array.isArray(videoModels) ? videoModels : []).forEach((model) => addModel(model, 'video'));
     return options;
-  }, [chatModels, imageModels]);
-
-  useEffect(() => {
-    if (modelRateDraft.modelId || rateLimitModelOptions.length === 0) return;
-    setModelRateDraft((current) => current.modelId ? current : { ...current, modelId: rateLimitModelOptions[0].id });
-  }, [rateLimitModelOptions, modelRateDraft.modelId]);
+  }, [chatModels, imageModels, videoModels]);
 
   const filteredUsers = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
@@ -493,11 +571,6 @@ const AdminPage = ({ collapsed }) => {
 
     return { nearingLimitUsers, cappedOutUsers };
   }, [users, limits]);
-
-  const modelMetaById = useMemo(() => {
-    const entries = rateLimitModelOptions.map((model) => [model.id, model]);
-    return new Map(entries);
-  }, [rateLimitModelOptions]);
 
   const beginEdit = (user) => {
     setError('');
@@ -551,11 +624,36 @@ const AdminPage = ({ collapsed }) => {
     setError('');
     setSuccess('');
     try {
+      const tiersPayload = {};
+      for (const key of TIER_KEYS) {
+        const form = limitForm.tiers?.[key] || EMPTY_TIER_LIMIT_FORM;
+        const limitRaw = String(form.limit ?? '').trim();
+        const amountRaw = String(form.windowAmount ?? '').trim();
+
+        if (!limitRaw && !amountRaw) {
+          tiersPayload[key] = { limit: '', windowSeconds: '' };
+          continue;
+        }
+
+        const limitNum = Number(limitRaw);
+        if (!Number.isInteger(limitNum) || limitNum <= 0) {
+          throw new Error(`The ${TIER_LABELS[key]} tier limit must be a positive whole number, or leave both fields blank.`);
+        }
+
+        const windowSeconds = getWindowSeconds(amountRaw, form.windowUnit);
+        if (!windowSeconds) {
+          throw new Error(`The ${TIER_LABELS[key]} tier window must be a positive whole number, or leave both fields blank.`);
+        }
+
+        tiersPayload[key] = { limit: limitNum, windowSeconds };
+      }
+
       const nextLimits = normalizeLimits(await updateUsageLimits({
-        turns: limitForm.turns.trim(),
-        images: limitForm.images.trim(),
-        videos: limitForm.videos.trim(),
-        modelRateLimits: normalizeModelRateLimits(limitForm.modelRateLimits)
+        turns: String(limitForm.turns ?? '').trim(),
+        images: String(limitForm.images ?? '').trim(),
+        videos: String(limitForm.videos ?? '').trim(),
+        tiers: tiersPayload,
+        modelTiers: limitForm.modelTiers || {}
       }) || DEFAULT_LIMITS);
       setLimits(nextLimits);
       setLimitForm(syncLimitForm(nextLimits));
@@ -568,48 +666,40 @@ const AdminPage = ({ collapsed }) => {
     }
   };
 
-  const handleAddModelRateLimit = () => {
-    const modelId = modelRateDraft.modelId.trim();
-    const limit = Number(modelRateDraft.limit);
-    const windowSeconds = getWindowSeconds(modelRateDraft.windowAmount, modelRateDraft.windowUnit);
-
-    setError('');
-    setSuccess('');
-
-    if (!modelId) {
-      setError('Choose a model for the rate limit.');
-      return;
-    }
-
-    if (!Number.isInteger(limit) || limit <= 0) {
-      setError('Rate limit requests must be a positive whole number.');
-      return;
-    }
-
-    if (!windowSeconds) {
-      setError('Rate limit window must be a positive whole number.');
-      return;
-    }
-
-    const nextRule = {
-      id: `${modelId.replace(/[^a-zA-Z0-9:_-]/g, '-')}-${limit}-${windowSeconds}-${Date.now()}`,
-      modelId,
-      limit,
-      windowSeconds
-    };
-
-    setLimitForm((current) => ({
-      ...current,
-      modelRateLimits: [...normalizeModelRateLimits(current.modelRateLimits), nextRule]
-    }));
-    setModelRateDraft((current) => ({ ...current, limit: '' }));
+  const handleTierFieldChange = (tier, field, value) => {
+    setLimitForm((current) => {
+      const currentTiers = current.tiers || { ...EMPTY_TIER_LIMIT_FORM_MAP };
+      const currentTier = currentTiers[tier] || { ...EMPTY_TIER_LIMIT_FORM };
+      return {
+        ...current,
+        tiers: {
+          ...currentTiers,
+          [tier]: { ...currentTier, [field]: value }
+        }
+      };
+    });
   };
 
-  const handleRemoveModelRateLimit = (ruleId) => {
+  const handleClearTier = (tier) => {
     setLimitForm((current) => ({
       ...current,
-      modelRateLimits: normalizeModelRateLimits(current.modelRateLimits).filter((rule) => rule.id !== ruleId)
+      tiers: {
+        ...(current.tiers || {}),
+        [tier]: { ...EMPTY_TIER_LIMIT_FORM }
+      }
     }));
+  };
+
+  const handleModelTierChange = (modelId, tier) => {
+    setLimitForm((current) => {
+      const next = { ...(current.modelTiers || {}) };
+      if (!tier) {
+        delete next[modelId];
+      } else {
+        next[modelId] = tier;
+      }
+      return { ...current, modelTiers: next };
+    });
   };
 
   const handleSaveDeepResearchConfig = async () => {
@@ -744,7 +834,23 @@ const AdminPage = ({ collapsed }) => {
     setArtifactChatConfigForm((current) => ({ ...current, [field]: value }));
   };
 
-  const modelRateLimitRules = normalizeModelRateLimits(limitForm.modelRateLimits);
+  const groupedRateLimitModels = useMemo(() => {
+    const groups = { chat: [], image: [], video: [] };
+    rateLimitModelOptions.forEach((model) => {
+      const kind = model.kind || 'chat';
+      if (!groups[kind]) groups[kind] = [];
+      groups[kind].push(model);
+    });
+    return groups;
+  }, [rateLimitModelOptions]);
+
+  const tierAssignmentCounts = useMemo(() => {
+    const counts = TIER_KEYS.reduce((acc, key) => { acc[key] = 0; return acc; }, {});
+    Object.values(limitForm.modelTiers || {}).forEach((tier) => {
+      if (counts[tier] !== undefined) counts[tier] += 1;
+    });
+    return counts;
+  }, [limitForm.modelTiers]);
 
   if (!adminUser) {
     return (
@@ -825,77 +931,127 @@ const AdminPage = ({ collapsed }) => {
             <RateLimitSection>
               <DRSectionHead>
                 <div>
-                  <DRSectionTitle>Model rate limits</DRSectionTitle>
-                  <Helper style={{ marginTop: 4 }}>Each rule applies per user account. Add more than one rule to enforce multiple reset windows for the same model.</Helper>
+                  <DRSectionTitle>Tier rate limits</DRSectionTitle>
+                  <Helper style={{ marginTop: 4 }}>
+                    Each tier has its own rolling window. Pro and Lite cover chat models you assign below; Image and Video cover all generations on those routes.
+                  </Helper>
                 </div>
               </DRSectionHead>
 
-              <RateLimitFormGrid>
-                <Field>
-                  <FieldLabel>Model</FieldLabel>
-                  <Input
-                    list="admin-model-rate-limit-models"
-                    placeholder="Model id"
-                    value={modelRateDraft.modelId}
-                    onChange={(e) => setModelRateDraft((current) => ({ ...current, modelId: e.target.value }))}
-                  />
-                  <datalist id="admin-model-rate-limit-models">
-                    {rateLimitModelOptions.map((model) => (
-                      <option key={model.id} value={model.id}>{`${model.kind || 'model'} ${model.provider || ''}`.trim()}</option>
-                    ))}
-                  </datalist>
-                </Field>
-                <Field>
-                  <FieldLabel>Requests</FieldLabel>
-                  <Input
-                    inputMode="numeric"
-                    placeholder="10"
-                    value={modelRateDraft.limit}
-                    onChange={(e) => setModelRateDraft((current) => ({ ...current, limit: e.target.value }))}
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel>Window</FieldLabel>
-                  <Input
-                    inputMode="numeric"
-                    placeholder="5"
-                    value={modelRateDraft.windowAmount}
-                    onChange={(e) => setModelRateDraft((current) => ({ ...current, windowAmount: e.target.value }))}
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel>Unit</FieldLabel>
-                  <Select
-                    value={modelRateDraft.windowUnit}
-                    onChange={(e) => setModelRateDraft((current) => ({ ...current, windowUnit: e.target.value }))}
-                  >
-                    <option value="seconds">Seconds</option>
-                    <option value="minutes">Minutes</option>
-                    <option value="hours">Hours</option>
-                    <option value="days">Days</option>
-                  </Select>
-                </Field>
-                <Button type="button" onClick={handleAddModelRateLimit} disabled={savingLimits}>Add rule</Button>
-              </RateLimitFormGrid>
-
-              <RateRuleList>
-                {modelRateLimitRules.length === 0 ? (
-                  <Helper>No model-specific rate limits configured.</Helper>
-                ) : modelRateLimitRules.map((rule) => {
-                  const modelMeta = modelMetaById.get(rule.modelId);
+              <TierGrid>
+                {TIER_KEYS.map((tier) => {
+                  const tierForm = limitForm.tiers?.[tier] || EMPTY_TIER_LIMIT_FORM;
+                  const savedTier = limits.tiers?.[tier] || {};
+                  const savedSummary = savedTier.limit && savedTier.windowSeconds
+                    ? `${savedTier.limit.toLocaleString('en-US')} per ${formatDuration(savedTier.windowSeconds)}`
+                    : 'No limit set';
                   return (
-                    <RateRuleRow key={rule.id}>
-                      <RuleModel>
-                        <RuleModelId>{rule.modelId}</RuleModelId>
-                        <RuleMeta>{[modelMeta?.kind, modelMeta?.provider].filter(Boolean).join(' / ') || 'custom model'}</RuleMeta>
-                      </RuleModel>
-                      <div>{rule.limit.toLocaleString('en-US')} requests</div>
-                      <div>per {formatDuration(rule.windowSeconds)}</div>
-                      <DangerButton type="button" onClick={() => handleRemoveModelRateLimit(rule.id)} disabled={savingLimits}>Remove</DangerButton>
-                    </RateRuleRow>
+                    <TierCard key={tier}>
+                      <TierCardHead>
+                        <div>
+                          <TierName>{TIER_LABELS[tier]}</TierName>
+                          <TierMeta>{TIER_DESCRIPTIONS[tier]}</TierMeta>
+                        </div>
+                        <TierClearButton
+                          type="button"
+                          onClick={() => handleClearTier(tier)}
+                          disabled={savingLimits || (!tierForm.limit && !tierForm.windowAmount)}
+                        >
+                          Clear
+                        </TierClearButton>
+                      </TierCardHead>
+
+                      <BigValue style={{ margin: 0 }}>{savedSummary}</BigValue>
+
+                      <TierFieldRow>
+                        <Field>
+                          <FieldLabel>Requests</FieldLabel>
+                          <Input
+                            inputMode="numeric"
+                            placeholder="Unlimited"
+                            value={tierForm.limit}
+                            onChange={(e) => handleTierFieldChange(tier, 'limit', e.target.value)}
+                          />
+                        </Field>
+                        <Field>
+                          <FieldLabel>Window</FieldLabel>
+                          <Input
+                            inputMode="numeric"
+                            placeholder="1"
+                            value={tierForm.windowAmount}
+                            onChange={(e) => handleTierFieldChange(tier, 'windowAmount', e.target.value)}
+                          />
+                        </Field>
+                        <Field>
+                          <FieldLabel>Unit</FieldLabel>
+                          <Select
+                            value={tierForm.windowUnit}
+                            onChange={(e) => handleTierFieldChange(tier, 'windowUnit', e.target.value)}
+                          >
+                            {Object.keys(WINDOW_UNIT_SECONDS).map((unit) => (
+                              <option key={unit} value={unit}>{WINDOW_UNIT_LABELS[unit] || unit}</option>
+                            ))}
+                          </Select>
+                        </Field>
+                      </TierFieldRow>
+
+                      <Helper style={{ marginTop: 0 }}>
+                        {tier === 'image' || tier === 'video'
+                          ? `${tierAssignmentCounts[tier] || 0} model${(tierAssignmentCounts[tier] || 0) === 1 ? '' : 's'} mapped (image/video routes default to this tier).`
+                          : `${tierAssignmentCounts[tier] || 0} chat model${(tierAssignmentCounts[tier] || 0) === 1 ? '' : 's'} assigned.`
+                        }
+                      </Helper>
+                    </TierCard>
                   );
                 })}
-              </RateRuleList>
+              </TierGrid>
+
+              <DRSectionHead>
+                <div>
+                  <DRSectionTitle>Model assignments</DRSectionTitle>
+                  <Helper style={{ marginTop: 4 }}>
+                    Pick the tier each model counts against. Chat models default to none (no limit). Image and video models inherit their route's tier when set to none.
+                  </Helper>
+                </div>
+              </DRSectionHead>
+
+              {[
+                { kind: 'chat', label: 'Chat models' },
+                { kind: 'image', label: 'Image models' },
+                { kind: 'video', label: 'Video models' }
+              ].map(({ kind, label }) => {
+                const list = groupedRateLimitModels[kind] || [];
+                if (list.length === 0) return null;
+                return (
+                  <ModelTierGroup key={kind}>
+                    <ModelTierGroupTitle>{label}</ModelTierGroupTitle>
+                    <ModelTierList>
+                      {list.map((model) => {
+                        const assigned = limitForm.modelTiers?.[model.id] || '';
+                        const choices = tiersAvailableForKind(model.kind);
+                        return (
+                          <ModelTierRow key={model.id}>
+                            <ModelTierLabel>
+                              <ModelTierName>{model.id}</ModelTierName>
+                              <ModelTierMeta>{[model.provider, model.apiId].filter(Boolean).join(' · ') || 'custom model'}</ModelTierMeta>
+                            </ModelTierLabel>
+                            <Select
+                              value={assigned}
+                              onChange={(e) => handleModelTierChange(model.id, e.target.value)}
+                              disabled={savingLimits}
+                            >
+                              <option value="">No limit</option>
+                              {choices.map((choice) => (
+                                <option key={choice} value={choice}>{TIER_LABELS[choice]}</option>
+                              ))}
+                            </Select>
+                          </ModelTierRow>
+                        );
+                      })}
+                    </ModelTierList>
+                  </ModelTierGroup>
+                );
+              })}
             </RateLimitSection>
 
             <Actions style={{ justifyContent: 'space-between' }}>
@@ -934,9 +1090,11 @@ const AdminPage = ({ collapsed }) => {
                 <Helper style={{ marginTop: 0 }}>Images first, videos second.</Helper>
               </LimitCard>
               <LimitCard>
-                <SmallLabel>Model rate rules</SmallLabel>
-                <BigValue>{(limits.modelRateLimits || []).length.toLocaleString('en-US')}</BigValue>
-                <Helper style={{ marginTop: 0 }}>Each active rule has its own reset window.</Helper>
+                <SmallLabel>Tier rate limits</SmallLabel>
+                <BigValue>
+                  {TIER_KEYS.filter((key) => limits.tiers?.[key]?.limit && limits.tiers?.[key]?.windowSeconds).length}/{TIER_KEYS.length}
+                </BigValue>
+                <Helper style={{ marginTop: 0 }}>Tiers with a configured limit and window.</Helper>
               </LimitCard>
             </SnapshotGrid>
           </Panel>

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -674,6 +674,49 @@ export const getImageModels = async () => {
   }
 };
 
+export const getVideoModels = async () => {
+  try {
+    const response = await fetchWithFallback('/video/models', {
+      method: 'GET'
+    });
+    const data = await parseJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to fetch available video models');
+    }
+    if (Array.isArray(data.models)) {
+      return data.models;
+    }
+    return [];
+  } catch (error) {
+    console.error('Get video models error:', error);
+    throw error;
+  }
+};
+
+export const getUserRateLimits = async () => {
+  try {
+    const user = getCurrentUser();
+    if (!user || !user.accessToken) {
+      throw new Error('User not authenticated');
+    }
+
+    const response = await fetchWithFallback('/auth/usage/rate-limits', {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${user.accessToken}`
+      }
+    });
+    const data = await parseJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to fetch rate limits');
+    }
+    return Array.isArray(data?.data?.buckets) ? data.data.buckets : [];
+  } catch (error) {
+    console.error('Get user rate limits error:', error);
+    throw error;
+  }
+};
+
 export const updateDeepResearchConfig = async (config) => {
   try {
     const response = await fetchWithFallback('/admin/deep-research/config', {


### PR DESCRIPTION
The freeform per-model rate limit editor in the admin panel was unclear and exposed too much surface area. Replace it with four named tier buckets (Pro, Lite, Image, Video). Each bucket has one limit + one window, and the admin assigns chat/image/video models to a tier in a clean per-kind list. Image and video routes default to their tier when no explicit assignment exists.

Add a "Rate limits" section to the bottom-left profile dropdown, modeled on Codex's pattern. It is a collapsible row alongside Settings / Info / Sign Out, with one entry per tier showing a small speedometer gauge, the tier label, and remaining count + reset time. The section shows "Unlimited" placeholders before any tier is configured so users always see the feature exists.

Backend changes:
- usageLimits.js: drop modelRateLimits[], add tiers + modelTiers shape; evaluateTierRateLimit + peekUserTierRateLimits replace evaluateModelRateLimits.
- chat/image/video routes call evaluateTierRateLimit with kind so image/video routes can fall back to their tier; 429 response now carries tier + tierLabel.
- auth.js: GET /api/auth/usage/rate-limits returns the four buckets for the current user without incrementing.
- video.js: switch to selective auth so /video/models can stay public for the admin assignment list. Add sora-2 to models.json under a new "video" section and expose listVideoModels().

Frontend changes:
- AdminPage rebuilds the rate-limits section: four tier cards with limit + window + unit, plus a per-kind model assignment list.
- Sidebar adds a collapsible "Rate limits" section in the profile dropdown with a speedometer gauge per tier, sized 16x16 to match the other dropdown icons.
- authService gains getVideoModels and getUserRateLimits.

Migration note: existing settings:usage-limits values will silently drop their modelRateLimits[] on the next admin save; tiers and modelTiers start empty and need to be configured fresh.