### PR TITLE
Pin chat title generation to gemini-3.1-flash-lite

### DIFF
--- a/frontend/src/config/modelConfig.js
+++ b/frontend/src/config/modelConfig.js
@@ -1,6 +1,8 @@
 export const DEFAULT_CHAT_MODEL_ID = 'gpt-5.4-mini';
 export const DEFAULT_CUSTOM_BASE_MODEL_ID = 'gpt-5.5';
-export const TITLE_GENERATION_MODEL_ID = DEFAULT_CHAT_MODEL_ID;
+// Pinned to a small, cheap, non-thinking model so chat title summarization stays
+// fast and doesn't drift when DEFAULT_CHAT_MODEL_ID changes.
+export const TITLE_GENERATION_MODEL_ID = 'gemini-3.1-flash-lite';
 export const NEWS_ASSIST_MODEL_ID = DEFAULT_CHAT_MODEL_ID;
 export const DEEP_RESEARCH_MODEL_ID = 'deep-research';
 

--- a/frontend/src/services/aiService.js
+++ b/frontend/src/services/aiService.js
@@ -655,8 +655,9 @@ export const generateChatTitle = async (userPrompt, assistantResponse) => {
     return null;
   }
   
-  const titlePrompt = `Summarize the following conversation in 3-4 words for a chat title.\n` +
-    `USER: ${userPrompt}\nASSISTANT: ${assistantResponse}\nTitle:`;
+  const titlePrompt = `Summarize the following conversation in a 3-5 word chat title. ` +
+    `Respond with ONLY the title text - no quotes, no punctuation, no explanation, no prefix.\n\n` +
+    `USER: ${userPrompt}\nASSISTANT: ${assistantResponse}\n\nTitle:`;
   try {
     const result = await sendMessageToBackend(
       TITLE_GENERATION_MODEL_ID,


### PR DESCRIPTION
TITLE_GENERATION_MODEL_ID was aliased to DEFAULT_CHAT_MODEL_ID, so when the default chat model switched from gemini-3-flash to gpt-5.4-mini in 46a1d29, title generation got dragged onto a reasoning-capable model that produces verbose, off-format output once the platform Sculptor system prompt is prepended on the backend.

Pin the title model explicitly to gemini-3.1-flash-lite so it stays fast and cheap regardless of the default chat model, and tighten the prompt to ask for 3-5 words with no quotes/punctuation/preamble so a small model resists the system prompt's personality nudges.