### PR TITLE
Make chat share link reachable when clipboard write fails

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -3,7 +3,7 @@ import styled, { withTheme } from 'styled-components';
 import ModelIcon from './ModelIcon'; // Assuming ModelIcon is correctly imported
 import { NavLink as RouterNavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from '../contexts/TranslationContext';
-import { createSharedChat, getSharedChatUrl } from '../services/shareService';
+import { copyToClipboard, createSharedChat, getSharedChatUrl } from '../services/shareService';
 import { getUserRateLimits } from '../services/authService';
 
 // Styled Components - Updated for Grok.com-inspired design
@@ -1115,17 +1115,27 @@ const Sidebar = ({
     const confirmed = window.confirm('Share this chat? The public page will include text only. Uploaded files, images, and hidden file context are removed.');
     if (!confirmed) return;
 
+    let shareUrl;
     try {
       const result = await createSharedChat(chat);
-      const shareUrl = getSharedChatUrl(result);
-      await navigator.clipboard.writeText(shareUrl);
-      setCopyStatus(t('sidebar.copySuccess'));
-      setTimeout(() => setCopyStatus(''), 3000);
+      shareUrl = getSharedChatUrl(result);
     } catch (err) {
-      console.error('Failed to copy share link: ', err);
+      console.error('Failed to create share link:', err);
       setCopyStatus(t('sidebar.copyFailure'));
       setTimeout(() => setCopyStatus(''), 3000);
+      return;
     }
+
+    const copied = await copyToClipboard(shareUrl);
+    if (copied) {
+      setCopyStatus(t('sidebar.copySuccess'));
+    } else {
+      // Auto-copy failed (insecure context, lost user activation, etc).
+      // Show the URL so the user can copy it manually.
+      window.prompt('Copy this share link:', shareUrl);
+      setCopyStatus(t('sidebar.copyFailure'));
+    }
+    setTimeout(() => setCopyStatus(''), 3000);
   };
 
   // Handle search functionality

--- a/frontend/src/components/mobile/MobileSidebar.jsx
+++ b/frontend/src/components/mobile/MobileSidebar.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { useTranslation } from '../../contexts/TranslationContext';
 import ModelIcon from '../ModelIcon';
-import { createSharedChat, getSharedChatUrl } from '../../services/shareService';
+import { copyToClipboard, createSharedChat, getSharedChatUrl } from '../../services/shareService';
 
 const SidebarOverlay = styled.div`
   position: fixed;
@@ -291,14 +291,23 @@ const MobileSidebar = ({
     const confirmed = window.confirm('Share this chat? The public page will include text only. Uploaded files, images, and hidden file context are removed.');
     if (!confirmed) return;
 
+    let shareUrl;
     try {
       const result = await createSharedChat(chat);
-      const shareUrl = getSharedChatUrl(result);
-      await navigator.clipboard.writeText(shareUrl);
-      alert(t('sidebar.copySuccess'));
+      shareUrl = getSharedChatUrl(result);
     } catch (err) {
-      console.error('Failed to copy share link: ', err);
+      console.error('Failed to create share link:', err);
       alert(t('sidebar.copyFailure'));
+      return;
+    }
+
+    const copied = await copyToClipboard(shareUrl);
+    if (copied) {
+      alert(t('sidebar.copySuccess'));
+    } else {
+      // Auto-copy failed (insecure context, lost user activation, etc).
+      // Show the URL so the user can copy it manually.
+      window.prompt('Copy this share link:', shareUrl);
     }
   };
 

--- a/frontend/src/services/shareService.js
+++ b/frontend/src/services/shareService.js
@@ -91,6 +91,53 @@ export const getSharedArtifactUrl = (shareResult) => normalizePublicShareUrl(
   shareResult?.id ? `/artifact/${encodeURIComponent(shareResult.id)}` : '/artifact'
 );
 
+export const copyToClipboard = async (text) => {
+  if (typeof text !== 'string' || !text) {
+    return false;
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.warn('Clipboard API failed, attempting execCommand fallback:', error);
+    }
+  }
+
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  let textarea;
+  try {
+    textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.width = '1px';
+    textarea.style.height = '1px';
+    textarea.style.opacity = '0';
+    textarea.style.pointerEvents = 'none';
+    document.body.appendChild(textarea);
+
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+
+    return document.execCommand('copy');
+  } catch (error) {
+    console.error('Fallback clipboard copy failed:', error);
+    return false;
+  } finally {
+    if (textarea && textarea.parentNode) {
+      textarea.parentNode.removeChild(textarea);
+    }
+  }
+};
+
 const parseJsonResponse = async (response) => {
   const data = await response.json().catch(() => ({}));
 


### PR DESCRIPTION
## Summary
- The share button on a chat called `navigator.clipboard.writeText` after `window.confirm` and an awaited share-creation API call. Both can cost the transient user activation that the Clipboard API requires, so the write would silently throw. The catch block only set a tiny status line at the bottom of the sidebar — the chat was shared on the server but the URL was unreachable.
- Added `copyToClipboard(text)` in `shareService.js` that tries `navigator.clipboard.writeText` first, then falls back to a temporary `<textarea>` + `document.execCommand('copy')`.
- Updated `handleShareChat` in both [Sidebar.jsx](https://github.com/Sculptor-AI/aiportal/blob/claude/interesting-blackwell-8ce94e/frontend/src/components/Sidebar.jsx) and [MobileSidebar.jsx](https://github.com/Sculptor-AI/aiportal/blob/claude/interesting-blackwell-8ce94e/frontend/src/components/mobile/MobileSidebar.jsx) to use the helper, separate "share creation failed" from "clipboard failed", and — if both copy paths fail — show the URL via `window.prompt` so the user can always select-and-copy the link manually.

## Why
Three-layer defense (Clipboard API → `execCommand` → visible `prompt` dialog) ensures the link is always reachable, even in non-secure contexts, when transient activation is lost after the async API round trip, or when the user denies clipboard permission.

## Test plan
- [ ] Sign in, hover an existing chat in the sidebar, click the share button — confirm dialog appears, then the share link is auto-copied and a "Share link copied to clipboard!" status shows at the bottom of the sidebar.
- [ ] Repeat in a browser where Clipboard API will fail (e.g. an HTTP origin) — the `window.prompt` should appear with the share URL pre-filled so it can be copied manually.
- [ ] Repeat in the mobile sidebar — same behavior, with `alert()` for success and `window.prompt` for the fallback.
- [ ] Cancel the initial confirm dialog — no share is created, no prompts appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)