### PR TITLE
Redirect to sign-in proactively when session expires

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,5 +1,7 @@
 import React, { createContext, useState, useEffect, useContext } from 'react';
-import { getCurrentUser, loginUser, logoutUser, registerUser, updateUserSettings, loginWithGoogle, adminLogin, adminLogout, getCurrentAdminUser } from '../services/authService';
+import { getCurrentUser, loginUser, logoutUser, registerUser, updateUserSettings, loginWithGoogle, adminLogin, adminLogout, getCurrentAdminUser, validateSession } from '../services/authService';
+
+const SESSION_REVALIDATE_INTERVAL_MS = 60_000;
 
 // Create the Auth Context
 const AuthContext = createContext();
@@ -16,23 +18,36 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Check if user is already logged in
+  // Check if user is already logged in, then verify the token with the backend
+  // so an expired session redirects to the login screen before any user action.
   useEffect(() => {
+    let cancelled = false;
+
     const checkUser = async () => {
       try {
         const currentUser = getCurrentUser();
         const currentAdminUser = getCurrentAdminUser();
-        setUser(currentUser);
-        setAdminUser(currentAdminUser);
+        if (!cancelled) {
+          setUser(currentUser);
+          setAdminUser(currentAdminUser);
+        }
+
+        if (currentUser?.accessToken) {
+          const validated = await validateSession();
+          if (!cancelled && !validated) {
+            setUser(null);
+          }
+        }
       } catch (err) {
         console.error('Authentication error:', err);
-        setError(err.message);
+        if (!cancelled) setError(err.message);
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
     checkUser();
+    return () => { cancelled = true; };
   }, []);
 
   // Listen for session expiry events dispatched by API services
@@ -45,6 +60,33 @@ export const AuthProvider = ({ children }) => {
     window.addEventListener('auth:session-expired', handleSessionExpired);
     return () => window.removeEventListener('auth:session-expired', handleSessionExpired);
   }, []);
+
+  // Keep the session check warm: revalidate on tab focus and on a periodic
+  // timer, so an expired token is detected without waiting for the user to
+  // send a message.
+  useEffect(() => {
+    if (!user?.accessToken) return undefined;
+
+    let cancelled = false;
+
+    const revalidate = async () => {
+      const validated = await validateSession();
+      if (!cancelled && !validated) {
+        setUser(null);
+      }
+    };
+
+    const handleFocus = () => { revalidate(); };
+
+    window.addEventListener('focus', handleFocus);
+    const intervalId = setInterval(revalidate, SESSION_REVALIDATE_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', handleFocus);
+      clearInterval(intervalId);
+    };
+  }, [user?.accessToken]);
 
   // Login function
   const login = async (username, password) => {

--- a/frontend/src/hooks/useMessageSender.js
+++ b/frontend/src/hooks/useMessageSender.js
@@ -859,17 +859,13 @@ const useMessageSender = ({
         error.message.includes('session has expired');
       
       if (isAuthError) {
-        const authErrorMessage = 'Your session has expired. Please log in again to continue.';
+        // The auth:session-expired event dispatched by aiService.js will
+        // clear the user in AuthContext, which causes the ForcedLoginScreen
+        // to render. Skip the alert/toast so the user is redirected cleanly
+        // instead of having to dismiss a "session expired" dialog first.
         updateMessage(currentChatId, aiMessageId, {
-          content: authErrorMessage,
+          content: 'Your session has expired. Redirecting to sign in…',
           isLoading: false, isError: true
-        });
-        addAlert({
-          message: authErrorMessage,
-          type: 'error',
-          autoHide: false,
-          actionText: 'Log In',
-          onAction: () => { window.location.href = '/login'; }
         });
       } else {
         const errorMessage = currentModelObj?.isCustomModel 

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,5 +1,5 @@
 // authService.js
-// Backend authentication service for AI Portal
+// Backend authentication service for AI Portal.
 
 import { getBackendApiBase } from './backendConfig';
 
@@ -194,6 +194,32 @@ export const getCurrentUser = () => {
   } catch (error) {
     localStorage.removeItem('ai_portal_current_user');
     return null;
+  }
+};
+
+// Verify the stored access token is still valid by hitting /auth/me.
+// Returns the user on success, null if the token is rejected (and clears
+// localStorage). Network errors leave the existing user in place.
+export const validateSession = async () => {
+  const user = getCurrentUser();
+  if (!user?.accessToken) return null;
+
+  try {
+    const response = await fetchWithFallback('/auth/me', {
+      method: 'GET',
+      headers: buildAuthHeaders(user.accessToken)
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      localStorage.removeItem('ai_portal_current_user');
+      window.dispatchEvent(new CustomEvent('auth:session-expired'));
+      return null;
+    }
+
+    return user;
+  } catch (error) {
+    console.warn('[authService] Session validation network error:', error?.message || error);
+    return user;
   }
 };
 


### PR DESCRIPTION
## Summary

Session-expiry handling was reactive: localStorage held a stale token, the app rendered as if logged in, and the user only discovered they were signed out when they sent a message and saw a blocking `Your session has expired. Please log in again to continue.` `OK`-button dialog. The UI behind it stayed put, so the dialog felt like a bait-and-switch on top of a "working" chat.

This change validates the session proactively and removes the dialog from the message-send path.

## Changes

- **`frontend/src/services/authService.js`** — new `validateSession()` that calls `/auth/me`; on `401`/`403` it clears `localStorage` and dispatches `auth:session-expired`. Network errors leave the existing user in place so a flaky connection doesn't log people out.
- **`frontend/src/contexts/AuthContext.jsx`** — verifies the token on `AuthProvider` mount (await `validateSession` before clearing the `loading` flag, so the chat UI never flashes on top of an expired session). Adds a second effect that revalidates on `window focus` and on a 60s interval while a user is logged in.
- **`frontend/src/hooks/useMessageSender.js`** — drops the `addAlert(...)` call for auth errors. `aiService.js` already dispatches `auth:session-expired` on a 401, which clears the user in `AuthContext` and causes `App.jsx` to render `ForcedLoginScreen`. The chat-bubble text is changed to "Your session has expired. Redirecting to sign in…" for the brief moment before that re-render lands.

## Why the dialog was specifically a `window.alert()`

`useMessageSender.js` calls `toast.showToast(...)` and falls back to `alert(...)` when that's undefined. `ToastContext` exposes `addToast`, `showSuccessToast`, `showErrorToast`, etc. — but **not** `showToast`. So every `toast.showToast` call across the codebase is silently a no-op, and the auth-error path was hitting the `alert()` fallback. That broader `ToastContext` API mismatch is out of scope here but worth a follow-up.

## Test plan

- [ ] Sign in, leave the tab open until the backend session expires → tab refocus or the 60s tick should route you to the sign-in screen with no dialog.
- [ ] Open a fresh tab with a known-expired token in `localStorage` → loading spinner, then sign-in screen. No flash of the chat UI.
- [ ] With a valid session, send a message → no regression; messages send normally.
- [ ] Take the backend offline mid-session → user stays logged in (network errors don't sign you out); reconnect, send a message → works.
- [ ] OAuth callback flow (`/auth/callback`) still completes and lands on the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)