### PR TITLE
Format model slugs into display names

### DIFF
--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -6,6 +6,7 @@
  */
 
 import modelsConfig from './models.json';
+import { formatModelSlugName } from '../utils/modelNames.js';
 
 /**
  * Get all model configurations
@@ -90,6 +91,7 @@ export function listImageModels() {
     for (const [name, apiId] of Object.entries(config.models || {})) {
       models.push({
         id: name,
+        name: formatModelSlugName(name),
         apiId: apiId,
         provider,
         isDefault: name === imageDefault
@@ -113,6 +115,7 @@ export function listVideoModels() {
     for (const [name, apiId] of Object.entries(config.models || {})) {
       models.push({
         id: name,
+        name: formatModelSlugName(name),
         apiId: apiId,
         provider,
         isDefault: name === videoDefault
@@ -193,6 +196,7 @@ export function listChatModels() {
 
       models.push({
         id: name,
+        name: formatModelSlugName(name),
         apiId: apiId,
         provider,
         isDefault: name === globalDefault,

--- a/backend/src/routes/health.js
+++ b/backend/src/routes/health.js
@@ -34,6 +34,7 @@ health.get('/models', (c) => {
     .filter(m => m.provider !== 'openai' || publicChatModelIds.has(m.id))
     .map(m => ({
       id: m.id,
+      name: m.name,
       apiId: m.apiId,
       provider: m.provider,
       isDefault: m.isDefault,

--- a/backend/src/utils/modelNames.js
+++ b/backend/src/utils/modelNames.js
@@ -1,0 +1,49 @@
+const TOKEN_OVERRIDES = {
+  ai: 'AI',
+  api: 'API',
+  chatgpt: 'ChatGPT',
+  dall: 'DALL',
+  gpt: 'GPT',
+  nvidia: 'NVIDIA',
+  tts: 'TTS'
+};
+
+const titleCaseToken = (token) => {
+  const lowerToken = token.toLowerCase();
+  if (TOKEN_OVERRIDES[lowerToken]) {
+    return TOKEN_OVERRIDES[lowerToken];
+  }
+
+  if (/^[a-z]+\d+$/i.test(token)) {
+    return `${token.charAt(0).toUpperCase()}${token.slice(1)}`;
+  }
+
+  return lowerToken.charAt(0).toUpperCase() + lowerToken.slice(1);
+};
+
+const mergeNumericVersionTokens = (tokens) => {
+  const mergedTokens = [];
+
+  for (const token of tokens) {
+    const previousToken = mergedTokens[mergedTokens.length - 1];
+    if (/^\d+$/.test(token) && /^\d+(?:\.\d+)*$/.test(previousToken || '')) {
+      mergedTokens[mergedTokens.length - 1] = `${previousToken}.${token}`;
+    } else {
+      mergedTokens.push(token);
+    }
+  }
+
+  return mergedTokens;
+};
+
+/**
+ * Convert a dash-delimited model slug into a human-readable display name.
+ * Examples: claude-opus-4.7 -> Claude Opus 4.7, gpt-5-4-mini -> GPT 5.4 Mini.
+ */
+export function formatModelSlugName(slug) {
+  if (!slug) return '';
+
+  return mergeNumericVersionTokens(String(slug).split('-').filter(Boolean))
+    .map(titleCaseToken)
+    .join(' ');
+}

--- a/backend/src/utils/modelNames.test.js
+++ b/backend/src/utils/modelNames.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatModelSlugName } from './modelNames.js';
+
+test('formatModelSlugName formats dash-delimited Claude model slugs', () => {
+  assert.equal(formatModelSlugName('claude-opus-4.7'), 'Claude Opus 4.7');
+  assert.equal(formatModelSlugName('claude-sonnet-4.6'), 'Claude Sonnet 4.6');
+});
+
+test('formatModelSlugName formats slugs consistently across model families', () => {
+  assert.equal(formatModelSlugName('gpt-5.4-mini'), 'GPT 5.4 Mini');
+  assert.equal(formatModelSlugName('gemini-3.1-flash-lite'), 'Gemini 3.1 Flash Lite');
+});
+
+test('formatModelSlugName treats consecutive numeric dash segments as dotted versions', () => {
+  assert.equal(formatModelSlugName('claude-opus-4-7'), 'Claude Opus 4.7');
+  assert.equal(formatModelSlugName('gpt-5-4-mini'), 'GPT 5.4 Mini');
+});


### PR DESCRIPTION
### Motivation
- Model identifiers are dash-delimited slugs (e.g. `claude-opus-4.7`) and need a consistent, human-readable display name across all families.
- The frontend expects a user-friendly `name` for each model to show in selectors and UI elements.
- Numeric version segments split by dashes should be merged into dotted versions (e.g. `4-7` -> `4.7`) and known acronyms should preserve casing.

### Description
- Added a shared formatter `formatModelSlugName` in `backend/src/utils/modelNames.js` that title-cases tokens, preserves common acronyms, and merges numeric version tokens into dotted versions.
- Wired the formatter into `listChatModels`, `listImageModels`, and `listVideoModels` in `backend/src/config/index.js` so each model object now includes a `name` field with the formatted display name.
- Updated the public `/models` response in `backend/src/routes/health.js` to include the formatted `name` for frontend consumption.
- Added unit tests `backend/src/utils/modelNames.test.js` covering Claude, GPT, Gemini, and dash-delimited numeric-version cases.

### Testing
- Ran the new and existing unit tests with `node --test backend/src/utils/modelNames.test.js backend/src/utils/providerFetch.test.js`, and all tests passed.
- Built the backend worker with `npm run build:worker --prefix backend`, which completed successfully.
- Performed smoke checks of `formatModelSlugName` in a REPL which produced expected outputs like `claude-opus-4.7 => Claude Opus 4.7`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f106385083259306786fd7f4e2ac)