### PR TITLE
Improve thinking preview streaming, timer styling, and LaTeX handling

### DIFF
--- a/frontend/src/components/ChatMessage.jsx
+++ b/frontend/src/components/ChatMessage.jsx
@@ -1644,19 +1644,14 @@ const ThinkingTimerBadge = styled.span`
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  min-width: 44px;
   margin-left: auto;
-  padding: 2px 8px;
-  border-radius: 999px;
-  border: 1px solid ${props => props.theme.accentColor || props.theme.primary || props.theme.text}33;
-  background: ${props => props.theme.accentSurface || `${props.theme.text}10`};
-  color: ${props => props.theme.accentColor || props.theme.primary || props.theme.text};
+  padding: 0;
+  color: ${props => `${props.theme.text}72`};
   font-variant-numeric: tabular-nums;
-  font-size: 0.78rem;
-  font-weight: 650;
-  letter-spacing: 0.01em;
-  line-height: 1.25;
-  box-shadow: inset 0 0 0 1px ${props => `${props.theme.text}08`};
+  font-size: 0.98rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.35;
 `;
 
 
@@ -1977,6 +1972,16 @@ const formatThinkingElapsed = (elapsedMs) => {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 };
 
+
+const getThinkingPreviewFromLatestText = (text = '') => {
+  const normalized = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+
+  const words = normalized.split(' ');
+  const previewWords = words.slice(-18);
+  return previewWords.join(' ');
+};
+
 const ThinkingTimer = ({ startedAt, completedAt, isStreaming }) => {
   const parsedStart = Date.parse(startedAt);
   const parsedCompleted = Date.parse(completedAt);
@@ -2004,6 +2009,7 @@ const ThinkingTimer = ({ startedAt, completedAt, isStreaming }) => {
 const ThinkingDropdown = ({
   thinkingContent,
   thinkingPreviewText = '',
+  latestThinkingPreviewText = '',
   toolCalls,
   isStreaming = false,
   theme = {},
@@ -2033,11 +2039,14 @@ const ThinkingDropdown = ({
     return t('chat.thinking.header.thoughts');
   };
 
-  const normalizedThinkingPreview = typeof thinkingPreviewText === 'string'
-    ? thinkingPreviewText.replace(/\s+/g, ' ').trim()
+  const explicitLatestPreview = typeof latestThinkingPreviewText === 'string'
+    ? latestThinkingPreviewText.replace(/\s+/g, ' ').trim()
     : '';
+  const normalizedThinkingPreview = explicitLatestPreview || getThinkingPreviewFromLatestText(thinkingPreviewText);
   const thinkingLabel = t('composer.chip.thinking', 'Thinking');
-  const headerText = normalizedThinkingPreview || (isStreaming ? t('chat.status.thinking') : getHeaderTitle());
+  const headerText = isStreaming
+    ? (normalizedThinkingPreview || t('chat.status.thinking'))
+    : getHeaderTitle();
 
   const getStatusIcon = (status) => {
     switch (status) {
@@ -2133,7 +2142,7 @@ const ThinkingDropdown = ({
 
 const ChatMessage = ({ message, showModelIcons = true, settings = {}, theme = {}, userProfilePicture = null, showProfileIcon = true }) => {
   const { t } = useTranslation();
-  const { role, content, timestamp, isError, isLoading, modelId, image, file, sources, type, status, imageUrl, prompt: imagePrompt, flowchartData, id, toolCalls, availableTools, codeExecution, codeExecutionResult, reasoningTrace, reasoningEffort, thinkingStartedAt, thinkingCompletedAt } = message;
+  const { role, content, timestamp, isError, isLoading, modelId, image, file, sources, type, status, imageUrl, prompt: imagePrompt, flowchartData, id, toolCalls, availableTools, codeExecution, codeExecutionResult, reasoningTrace, reasoningPreviewText, reasoningEffort, thinkingStartedAt, thinkingCompletedAt } = message;
   const { supportedLanguages, isLanguageExecutable } = useSupportedLanguages();
   const [isExportingPdf, setIsExportingPdf] = useState(false);
   const [deepResearchDetailsOpen, setDeepResearchDetailsOpen] = useState(false);
@@ -2921,6 +2930,7 @@ const ChatMessage = ({ message, showModelIcons = true, settings = {}, theme = {}
                     <ThinkingDropdown
                       thinkingContent={formattedThinkingContent}
                       thinkingPreviewText={combinedThinkingText}
+                      latestThinkingPreviewText={isLoading ? reasoningPreviewText : ''}
                       toolCalls={toolCalls}
                       isStreaming={isLoading}
                       theme={theme}

--- a/frontend/src/components/StreamingMarkdownRenderer.jsx
+++ b/frontend/src/components/StreamingMarkdownRenderer.jsx
@@ -827,6 +827,25 @@ const createArtifactFromCodeBlock = (language, codeContent, placement) => create
   fallbackTitle: placement === 'inline' ? 'Inline artifact' : 'Artifact'
 });
 
+
+const normalizeLatexDelimiters = (source = '') => {
+  const text = String(source || '');
+  if (!text.includes('\\(') && !text.includes('\\[')) {
+    return text;
+  }
+
+  const segments = text.split(/(```[\s\S]*?```|`[^`\n]*`)/g);
+  return segments.map((segment) => {
+    if (!segment || segment.startsWith('```') || segment.startsWith('`')) {
+      return segment;
+    }
+
+    return segment
+      .replace(/\\\[([\s\S]*?)\\\]/g, (_match, math) => `$$${math}$$`)
+      .replace(/\\\(([\s\S]*?)\\\)/g, (_match, math) => `$${math}$`);
+  }).join('');
+};
+
 const StreamingMarkdownRenderer = ({ 
   text = '', 
   isStreaming = false,
@@ -835,9 +854,10 @@ const StreamingMarkdownRenderer = ({
   enableCodeExecution = true
 }) => {
   const { supportedLanguages, isLanguageExecutable } = useSupportedLanguages();
-  const artifactSegments = useMemo(() => getStreamingArtifactSegments(text, isStreaming), [text, isStreaming]);
+  const normalizedText = useMemo(() => normalizeLatexDelimiters(text), [text]);
+  const artifactSegments = useMemo(() => getStreamingArtifactSegments(normalizedText, isStreaming), [normalizedText, isStreaming]);
 
-  if (!text) {
+  if (!normalizedText) {
     return isStreaming && showCursor ? <Cursor $show={true} theme={theme}>|</Cursor> : null;
   }
 
@@ -871,7 +891,10 @@ const StreamingMarkdownRenderer = ({
     code({node, inline, className, children, ...props}) {
       const match = /language-([^\s]+)/.exec(className || '');
       const language = match ? match[1] : '';
-      if (!inline) {
+      const position = node?.position;
+      const spansMultipleLines = Boolean(position && position.start?.line !== position.end?.line);
+      const isBlockCode = inline === false || Boolean(className) || spansMultipleLines;
+      if (isBlockCode) {
         if (isMermaidLanguage(language)) {
           return <MermaidArtifact chart={children} theme={theme} isStreaming={isStreaming} />;
         }

--- a/frontend/src/hooks/useMessageSender.js
+++ b/frontend/src/hooks/useMessageSender.js
@@ -643,6 +643,7 @@ const useMessageSender = ({
       role: 'assistant',
       content: '',
       reasoningTrace: '',
+      reasoningPreviewText: '',
       isLoading: true,
       timestamp: thinkingStartedAt,
       modelId: currentModel,
@@ -717,10 +718,12 @@ const useMessageSender = ({
 
           // Handle provider-native reasoning deltas
           if (typeof chunk === 'object' && chunk.type === 'reasoning') {
-            reasoningTrace += chunk.content || '';
+            const reasoningDelta = chunk.content || '';
+            reasoningTrace += reasoningDelta;
             updateMessage(currentChatId, aiMessageId, {
               content: streamedContent,
               reasoningTrace,
+              reasoningPreviewText: reasoningDelta,
               isLoading: true,
               toolCalls: toolCalls.length > 0 ? [...toolCalls] : undefined
             });
@@ -840,6 +843,7 @@ const useMessageSender = ({
 
         if (reasoningTrace) {
           messageUpdates.reasoningTrace = reasoningTrace;
+          messageUpdates.reasoningPreviewText = '';
         }
         
         // Add tool calls if we have them


### PR DESCRIPTION
### Motivation
- The thinking/`<think>` UI showed the start of the accumulated reasoning text instead of previewing the most recent streaming delta, and the timer appeared visually as a boxed badge that drew undue attention. 
- LaTeX sometimes failed to render when upstream content used `\(…\)` / `\[…\]` delimiters or when inline code fences confused the markdown renderer, breaking math rendering in streaming contexts.

### Description
- Store the latest reasoning delta separately as `reasoningPreviewText` and surface it to the collapsed thinking indicator so the preview shows the newest chunk while streaming. (changes in `frontend/src/hooks/useMessageSender.js` and `frontend/src/components/ChatMessage.jsx`).
- Restyle the thinking timer to remove the pill/border/background and render as subtle inline grey text that matches surrounding copy (`frontend/src/components/ChatMessage.jsx`).
- Normalize common LaTeX delimiter forms by converting `\\(...\\)` and `\\[...\\]` into `$...$` / `$$...$$` while preserving code spans/fences, so `remark-math` + `rehype-katex` can render math reliably during streaming (`frontend/src/components/StreamingMarkdownRenderer.jsx`).
- Improve code-block detection in markdown renderers so inline code spans are not misclassified as block code (look at node `position` and className) which reduces interference with inline math/text rendering (`frontend/src/components/StreamingMarkdownRenderer.jsx`).

### Testing
- Built the frontend with `npm run build --prefix frontend` and the production build completed successfully without build-time LaTeX asset errors. 
- Ran a repository static change check with `git diff --check` which reported no whitespace/merge conflict issues. 
- Manual exercised streaming flows locally to confirm the thinking preview updates with the latest delta and that the timer now appears as subtle inline text; LaTeX inline and display math rendered correctly in streaming messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3d2d91548325be30634473d02bd4)