### PR TITLE
Replace Gemini 3 Flash with Gemini 3.5 Flash as default researcher model

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ SCULPTOR_AI_SYSTEM_PROMPT="The assistant is Sculptor, created by SculptorAI."
 
 # Optional deep research overrides
 DEEP_RESEARCH_PLANNER_MODEL=gemini-3.1-pro
-DEEP_RESEARCH_RESEARCHER_MODEL=gemini-3-flash
+DEEP_RESEARCH_RESEARCHER_MODEL=gemini-3.5-flash
 DEEP_RESEARCH_WRITER_MODEL=claude-sonnet-4.6
 DEEP_RESEARCH_MAX_AGENTS=12
 ```

--- a/backend/.dev.vars.example
+++ b/backend/.dev.vars.example
@@ -74,7 +74,7 @@ DEEP_RESEARCH_ENABLED="true"
 
 # Planner / researcher / writer model names (mapped through src/config/models.json)
 DEEP_RESEARCH_PLANNER_MODEL="gemini-3.1-pro"
-DEEP_RESEARCH_RESEARCHER_MODEL="gemini-3-flash"
+DEEP_RESEARCH_RESEARCHER_MODEL="gemini-3.5-flash"
 DEEP_RESEARCH_WRITER_MODEL="claude-sonnet-4.6"
 DEEP_RESEARCH_REPORT_LENGTH="standard"
 DEEP_RESEARCH_REPORT_DEPTH="standard"

--- a/backend/src/config/models.json
+++ b/backend/src/config/models.json
@@ -86,7 +86,7 @@
     "gemini": {
       "models": {
         "gemini-3.1-pro": "gemini-3.1-pro-preview",
-        "gemini-3-flash": "gemini-3-flash-preview",
+        "gemini-3.5-flash": "gemini-3.5-flash-preview",
         "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview"
       },
       "modelCapabilities": {
@@ -100,7 +100,7 @@
           "reasoning_effort_default": "high",
           "thinking_style": "level"
         },
-        "gemini-3-flash": {
+        "gemini-3.5-flash": {
           "reasoning_effort": true,
           "reasoning_effort_levels": [
             "minimal",

--- a/backend/src/utils/deepResearchSettings.js
+++ b/backend/src/utils/deepResearchSettings.js
@@ -2,7 +2,7 @@ const DEEP_RESEARCH_SETTINGS_KEY = 'settings:deep-research';
 
 export const DEEP_RESEARCH_SETTINGS_DEFAULTS = Object.freeze({
   plannerModel: 'gemini-3.1-pro',
-  researcherModel: 'gemini-3-flash',
+  researcherModel: 'gemini-3.5-flash',
   writerModel: 'claude-sonnet-4.6',
   reportLength: 'standard',
   reportDepth: 'standard',

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -47,7 +47,7 @@ const DEFAULT_LIMITS = {
 };
 const DEFAULT_DEEP_RESEARCH_CONFIG = {
   plannerModel: 'gemini-3.1-pro',
-  researcherModel: 'gemini-3-flash',
+  researcherModel: 'gemini-3.5-flash',
   writerModel: 'claude-sonnet-4.6',
   reportLength: 'standard',
   reportDepth: 'standard',


### PR DESCRIPTION
### Motivation
- Upgrade the default deep-research researcher model from `gemini-3-flash` to `gemini-3.5-flash` and ensure the model mapping and capability wiring remain correct for routing and feature checks.

### Description
- Renamed the Gemini chat model key and preview mapping in `backend/src/config/models.json` from `gemini-3-flash` -> `gemini-3.5-flash` and preserved the same `modelCapabilities` (reasoning effort levels and `computer_use`).
- Updated the backend deep-research default to `gemini-3.5-flash` in `backend/src/utils/deepResearchSettings.js` and the frontend admin default in `frontend/src/pages/AdminPage.jsx` to keep UI and backend aligned.
- Updated environment/example and docs references in `backend/.dev.vars.example` and `README.md` to reflect `DEEP_RESEARCH_RESEARCHER_MODEL=gemini-3.5-flash`.

### Testing
- Ran `node --check backend/src/utils/deepResearchSettings.js` and `node --check backend/src/config/deepResearch.js`, which completed successfully.
- Validated `backend/src/config/models.json` with `python -m json.tool backend/src/config/models.json`, which succeeded.
- Attempted `node --check` on the frontend `.jsx` file but the local `node --check` invocation cannot parse `.jsx` and produced `ERR_UNKNOWN_FILE_EXTENSION`, so no automated syntax check was performed for that file in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca4d394dc8325a71b2176f566d631)