### PR TITLE
Add Claude Opus 4.8 model

### DIFF
--- a/backend/src/config/models.json
+++ b/backend/src/config/models.json
@@ -1,6 +1,6 @@
 {
   "_description": "Centralized model configuration. Update this file when models change.",
-  "_lastUpdated": "2026-05-05",
+  "_lastUpdated": "2026-05-28",
 
   "default": "gpt-5.5",
 
@@ -44,11 +44,27 @@
 
     "anthropic": {
       "models": {
+        "claude-opus-4.8": "claude-opus-4-8",
         "claude-opus-4.7": "claude-opus-4-7",
         "claude-sonnet-4.6": "claude-sonnet-4-6",
         "claude-haiku-4.5": "claude-haiku-4-5-20251001"
       },
       "modelCapabilities": {
+        "claude-opus-4.8": {
+          "reasoning_effort": true,
+          "reasoning_effort_levels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoning_effort_default": "medium",
+          "thinking_style": "adaptive",
+          "adaptive_thinking_only": true,
+          "default_thinking_display": "summarized",
+          "supports_task_budgets": true
+        },
         "claude-opus-4.7": {
           "reasoning_effort": true,
           "reasoning_effort_levels": [

--- a/backend/src/utils/modelNames.test.js
+++ b/backend/src/utils/modelNames.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { formatModelSlugName } from './modelNames.js';
 
 test('formatModelSlugName formats dash-delimited Claude model slugs', () => {
+  assert.equal(formatModelSlugName('claude-opus-4.8'), 'Claude Opus 4.8');
   assert.equal(formatModelSlugName('claude-opus-4.7'), 'Claude Opus 4.7');
   assert.equal(formatModelSlugName('claude-sonnet-4.6'), 'Claude Sonnet 4.6');
 });
@@ -14,6 +15,7 @@ test('formatModelSlugName formats slugs consistently across model families', () 
 });
 
 test('formatModelSlugName treats consecutive numeric dash segments as dotted versions', () => {
+  assert.equal(formatModelSlugName('claude-opus-4-8'), 'Claude Opus 4.8');
   assert.equal(formatModelSlugName('claude-opus-4-7'), 'Claude Opus 4.7');
   assert.equal(formatModelSlugName('gpt-5-4-mini'), 'GPT 5.4 Mini');
 });

--- a/frontend/src/components/ModelIcon.jsx
+++ b/frontend/src/components/ModelIcon.jsx
@@ -66,10 +66,12 @@ const MODEL_LOGOS = {
 
   // Claude models
   'claude-3.7-sonnet': '/images/claude-logo.png',
+  'claude-opus-4.8': '/images/claude-logo.png',
   'claude-opus-4.7': '/images/claude-logo.png',
   'anthropic/claude-3-haiku': '/images/claude-logo.png',
   'anthropic/claude-3-opus': '/images/claude-logo.png',
   'anthropic/claude-3-sonnet': '/images/claude-logo.png',
+  'claude-opus-4-8': '/images/claude-logo.png',
   'claude-opus-4-7': '/images/claude-logo.png',
 
   // Grok models

--- a/frontend/src/styles/themes.js
+++ b/frontend/src/styles/themes.js
@@ -687,6 +687,11 @@ export const modelThemes = {
     secondary: '#EA4335',
     gradient: 'linear-gradient(135deg, #1B72E8, #EA4335)',
   },
+  'claude-opus-4.8': {
+    primary: '#4C1D95',
+    secondary: '#6D28D9',
+    gradient: 'linear-gradient(135deg, #4C1D95, #6D28D9)',
+  },
   'claude-opus-4.7': {
     primary: '#5B21B6',
     secondary: '#7C3AED',


### PR DESCRIPTION
### Motivation
- Add the new Anthropic Opus 4.8 model to the app so it is selectable and presented consistently in both backend model registry and frontend UI.

### Description
- Added `claude-opus-4.8` -> `claude-opus-4-8` to `backend/src/config/models.json` and included Opus reasoning/adaptive thinking capabilities matching Opus 4.7 settings.
- Added logo mappings for `claude-opus-4.8` and API-style `claude-opus-4-8` in `frontend/src/components/ModelIcon.jsx` so the UI shows the Claude logo for the new ID variants.
- Added a model theme entry for `claude-opus-4.8` in `frontend/src/styles/themes.js` to provide badge colors/gradient for the new model.
- Extended unit tests in `backend/src/utils/modelNames.test.js` to cover `claude-opus-4.8` (dot and dash variants) for display-name formatting.

### Testing
- Ran `node --test backend/src/utils/modelNames.test.js` and all tests passed (`3 passed, 0 failed`).
- Validated `backend/src/config/models.json` parsing with `node -e "JSON.parse(require('fs').readFileSync('backend/src/config/models.json','utf8'))"` which succeeded.
- Ran a small Node script to verify `listChatModels()`/`resolveModel()` mapping for `claude-opus-4.8` which confirmed the model and API ID were present and capabilities populated.
- Attempted `npm run build` but the frontend build could not run in this environment because `vite` is not installed (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18b0a80ae88324b344e53d3909a1a8)